### PR TITLE
Urgent bugfix

### DIFF
--- a/src/interface.c
+++ b/src/interface.c
@@ -1104,8 +1104,6 @@ int confirm_ui(pixel *vid_buf, char *top, char *msg, char *btn)
 			break;
 	}
 
-	free(msg);
-
 	while (!sdl_poll())
 	{
 		b = SDL_GetMouseState(&mx, &my);
@@ -5568,6 +5566,8 @@ int save_filename_ui(pixel *vid_buf)
 					}
 				}
 				fclose(f);
+
+				free(filename);
 				
 			}
 		}


### PR DESCRIPTION
confirm_ui() free()ed its msg. This resulted in attemps to free const
strings or and to invalid memoory accesses (because some other functions
wanted to reuse the parameter which they gave to confirm_ui() after
calling this function).

Resolved by removing the call to free() from confirm_ui() and adding it
after the calls to confirm_ui(9, if necessary.
