### PR TITLE
Fix build – Remove <version.h> include

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -48,7 +48,6 @@
 #include "gravity.h"
 #include <graphics.h>
 #include <powdergraphics.h>
-#include <version.h>
 #include <http.h>
 #include <md5.h>
 #include <update.h>


### PR DESCRIPTION
The last commit removed the empty includes/version.h. But as src/main.c
still refers to it, that causes the build to fail.

Fixes commit a1aeabe
