### PR TITLE
Mac Build Fix for no FFT

### DIFF
--- a/SConscript
+++ b/SConscript
@@ -43,6 +43,7 @@ AddOption('--sse',dest="sse",action='store_true',default=False,help="Enable SSE 
 AddOption('--sse2',dest="sse2",action='store_true',default=False,help="Enable SSE2 optimisations")
 AddOption('--sse3',dest="sse3",action='store_true',default=False,help="Enable SSE3 optimisations")
 AddOption('--x86',dest="x86",action='store_true',default=True,help="Target Intel x86 platform")
+AddOption('--nofft',dest="nofft", action='store_true',default=False,help="Do not use fftw3f for gravity.")
 
 AddOption('--debugging', dest="debug", action="store_true", default=False, help="Enable debug options")
 AddOption('--beta',dest="beta",action='store_true',default=False,help="Beta build.")
@@ -52,7 +53,6 @@ AddOption('--build-number',dest="build-number",default=False,help="Build number.
 AddOption('--snapshot',dest="snapshot",action='store_true',default=False,help="Snapshot build.")
 AddOption('--snapshot-id',dest="snapshot-id",default=False,help="Snapshot build ID.")
 AddOption('--stable',dest="stable",default=True,help="Non snapshot build")
-
 AddOption('--aao', dest="everythingAtOnce", action='store_true', default=False, help="Compile the whole game without generating intermediate objects (very slow), enable this when using compilers like clang or mscc that don't support -fkeep-inline-functions")
 
 if((not GetOption('lin')) and (not GetOption('win')) and (not GetOption('rpi')) and (not GetOption('macosx'))):
@@ -127,13 +127,16 @@ if not GetOption("macosx"):
 
 	env = conf.Finish();
 else:
-	env.Append(LIBS=['z', 'bz2', 'fftw3f'])
+	env.Append(LIBS=['z', 'bz2'])
+	if not GetOption('nofft'):
+		env.Append(LIBS=['fftw3f'])
 
 env.Append(CPPPATH=['src/', 'data/', 'generated/'])
 env.Append(CCFLAGS=['-w', '-std=c++98', '-fkeep-inline-functions'])
 env.Append(LIBS=['pthread', 'm'])
-env.Append(CPPDEFINES=["LUACONSOLE", "GRAVFFT", "_GNU_SOURCE", "USE_STDINT", "_POSIX_C_SOURCE=200112L"])
-
+env.Append(CPPDEFINES=["LUACONSOLE", "_GNU_SOURCE", "USE_STDINT", "_POSIX_C_SOURCE=200112L"])
+if not GetOption('nofft'):
+	env.Append(CPPDEFINES=["GRAVFFT"])
 if GetOption("ptw32-static"):
 	env.Append(CPPDEFINES=['PTW32_STATIC_LIB']);
 
@@ -178,7 +181,8 @@ if(GetOption('macosx')):
 	env.Append(CPPDEFINES=["MACOSX"])
 	env.Append(CCFLAGS=['-I/Library/Frameworks/SDL.framework/Headers'])
 	env.Append(CCFLAGS=['-I/Library/Frameworks/Lua.framework/Headers'])
-	env.Append(LINKFLAGS=['-lfftw3f'])
+	if not GetOption('nofft'):
+		env.Append(LINKFLAGS=['-lfftw3f'])
 	env.Append(LINKFLAGS=['-framework'])
 	env.Append(LINKFLAGS=['SDL'])
 	env.Append(LINKFLAGS=['-framework'])

--- a/src/simulation/Gravity.cpp
+++ b/src/simulation/Gravity.cpp
@@ -514,13 +514,18 @@ void Gravity::gravity_mask()
 	}
 	mask_free(t_mask_el);
 }
-
+#ifdef GRAVFFT
 Gravity::Gravity():
-		grav_fft_status(false)
+	grav_fft_status(false)
 {
 	gravity_init();
 }
-
+#else
+Gravity::Gravity()
+{
+	gravity_init();
+}
+#endif
 Gravity::~Gravity()
 {
 	gravity_cleanup();


### PR DESCRIPTION
Added option to Sconscript to check if the user wants to compile with fftw3, a very out of date library which won't work on newer macs. Also fixed problem at bottom of Gravity.cpp, where it wasn't checking to see if it should use GRAVFFT or not. Could someone please check if I broke anything on the build on windows/linux?
