### PR TITLE
fix dropper debug printing

### DIFF
--- a/src/gui/game/GameModel.cpp
+++ b/src/gui/game/GameModel.cpp
@@ -513,7 +513,9 @@ Menu * GameModel::GetActiveMenu()
 
 Tool * GameModel::GetElementTool(int elementID)
 {
+#ifdef DEBUG
 	std::cout << elementID << std::endl;
+#endif
 	for(std::vector<Tool*>::iterator iter = elementTools.begin(), end = elementTools.end(); iter != end; ++iter)
 	{
 		if((*iter)->GetToolID() == elementID)


### PR DESCRIPTION
When sampling a thing, it used to print sampled element's ID into stdout
well, i had to do some serious gdb investigation to find where is the text actually produced...
