### PR TITLE
fix segfault on wordwrapping a string with a character >128

### DIFF
--- a/src/graphics/Graphics.cpp
+++ b/src/graphics/Graphics.cpp
@@ -589,7 +589,7 @@ int Graphics::textwidth(const char *s)
 	return x-1;
 }
 
-int Graphics::CharWidth(char c)
+int Graphics::CharWidth(unsigned char c)
 {
 	return font_data[font_ptrs[(int)c]];
 }

--- a/src/graphics/Graphics.h
+++ b/src/graphics/Graphics.h
@@ -203,7 +203,7 @@ public:
 	//Font/text metrics
 	static int CharIndexAtPosition(char *s, int positionX, int positionY);
 	static int PositionAtCharIndex(char *s, int charIndex, int & positionX, int & positionY);
-	static int CharWidth(char c);
+	static int CharWidth(unsigned char c);
 	static int textnwidth(char *s, int n);
 	static void textnpos(char *s, int n, int w, int *cx, int *cy);
 	static int textwidthx(char *s, int w);


### PR DESCRIPTION
signed char causes character code to overflow into negative values, Graphics::CharWidth then converts it to int, leaving the negative-ness, font_ptrs is then indexed with a negative value
