### PR TITLE
ContextMenu

### DIFF
--- a/src/gui/interface/ContextMenu.cpp
+++ b/src/gui/interface/ContextMenu.cpp
@@ -30,9 +30,14 @@ void ContextMenu::Show(ui::Point position)
 	}
 	buttons.clear();
 
-	Position = position;
-	Size.Y = items.size()*16;
 	Size.X = 100;
+	Size.Y = items.size()*16-1;
+
+	if(position.X+Size.X > XRES+BARSIZE)
+		position.X -= std::min(position.X, Size.X);
+	if(position.Y+Size.Y > YRES+MENUSIZE)
+		position.Y -= std::min(position.Y, Size.Y);
+	Position = position;
 
 	int currentY = 1;
 	for(int i = 0; i < items.size(); i++)


### PR DESCRIPTION
Fixes #188.
if the menu goes beyond right edge, flip it so that the cursor will be at its top-right edge instead of top-left. If it still doesn't fit (goes beyond left edge [possible with huge menus, i'm guessing?]), just give it an X of 0. Same goes for Y.
