### PR TITLE
Extension to tpt.screenshot

### DIFF
--- a/src/Format.cpp
+++ b/src/Format.cpp
@@ -153,6 +153,58 @@ VideoBuffer * format::PTIToVideoBuffer(std::vector<char> & data)
 	return NULL;
 }
 
+void write_int_to_char(char* charArray,int pos,int value)
+{
+	charArray[pos] = (value)&0xFF;
+	charArray[pos+1] = (value>>8)&0xFF;
+	charArray[pos+2] = (value>>16)&0xFF;
+	charArray[pos+3] = (value>>24)&0xFF;
+}
+
+std::vector<char> format::VideoBufferToBMP(const VideoBuffer & vidBuf)
+{
+	std::vector<char> data;
+	char buffer[54] = "BM";
+	unsigned int fileSize = (ceil((double)vidBuf.Width*3/4)*vidBuf.Height*4)+54;
+	write_int_to_char(buffer,2,fileSize);
+	write_int_to_char(buffer,6,0);
+	write_int_to_char(buffer,10,0x36);
+	write_int_to_char(buffer,14,0x28);
+	write_int_to_char(buffer,18,vidBuf.Width);
+	write_int_to_char(buffer,22,vidBuf.Height);
+	write_int_to_char(buffer,26,0x180001);
+	write_int_to_char(buffer,30,0);
+	write_int_to_char(buffer,34,fileSize-54);
+	write_int_to_char(buffer,38,0xB13);
+	write_int_to_char(buffer,42,0xB13);
+	write_int_to_char(buffer,46,0);
+	write_int_to_char(buffer,50,0);
+	
+	data.insert(data.end(), buffer, buffer+54);
+	
+	int padding = (ceil((double)vidBuf.Width*3/4)*4) - (vidBuf.Width*3);
+
+	unsigned char * currentRow = new unsigned char[(vidBuf.Width*3)+padding];
+	for(int y = vidBuf.Height - 1; y >= 0; y--)
+	{
+		int rowPos = 0;
+		for(int x = 0; x < vidBuf.Width; x++)
+		{
+			currentRow[rowPos++] = PIXB(vidBuf.Buffer[(y*vidBuf.Width)+x]);
+			currentRow[rowPos++] = PIXG(vidBuf.Buffer[(y*vidBuf.Width)+x]);
+			currentRow[rowPos++] = PIXR(vidBuf.Buffer[(y*vidBuf.Width)+x]);
+		}
+		for(int i = 0; i < padding; i++)
+		{
+			currentRow[rowPos++] = 0;
+		}
+		data.insert(data.end(), currentRow, currentRow+(vidBuf.Width*3)+padding);
+	}
+	delete currentRow;
+
+	return data;
+}
+
 std::vector<char> format::VideoBufferToPPM(const VideoBuffer & vidBuf)
 {
 	std::vector<char> data;

--- a/src/Format.h
+++ b/src/Format.h
@@ -31,6 +31,7 @@ namespace format
 	std::string CleanString(char * dirtyData, int maxVisualSize, int maxStringLength);
 	std::string CleanString(char * dirtyData, int maxStringLength);
 	std::vector<char> VideoBufferToPNG(const VideoBuffer & vidBuf);
+	std::vector<char> VideoBufferToBMP(const VideoBuffer & vidBuf);
 	std::vector<char> VideoBufferToPPM(const VideoBuffer & vidBuf);
 	std::vector<char> VideoBufferToPTI(const VideoBuffer & vidBuf);
 	VideoBuffer * PTIToVideoBuffer(std::vector<char> & data);

--- a/src/cat/LegacyLuaAPI.cpp
+++ b/src/cat/LegacyLuaAPI.cpp
@@ -2023,36 +2023,38 @@ int luatpt_screenshot(lua_State* l)
 	int captureUI = luaL_optint(l, 1, 0);
 	int fileType = luaL_optint(l, 2, 0);
 	std::vector<char> data;
-	if(fileType) {
-		if(captureUI)
-		{
-			VideoBuffer screenshot(ui::Engine::Ref().g->DumpFrame());
+	if(captureUI)
+	{
+		VideoBuffer screenshot(ui::Engine::Ref().g->DumpFrame());
+		if(fileType == 1) {
+			data = format::VideoBufferToBMP(screenshot);
+		} else if(fileType == 2) {
 			data = format::VideoBufferToPPM(screenshot);
-		}
-		else
-		{
-			VideoBuffer screenshot(luacon_ren->DumpFrame());
-			data = format::VideoBufferToPPM(screenshot);
+		} else {
+			data = format::VideoBufferToPNG(screenshot);
 		}
 	}
 	else
 	{
-		if(captureUI)
-		{
-			VideoBuffer screenshot(ui::Engine::Ref().g->DumpFrame());
-			data = format::VideoBufferToPNG(screenshot);
-		}
-		else
-		{
-			VideoBuffer screenshot(luacon_ren->DumpFrame());
+		VideoBuffer screenshot(luacon_ren->DumpFrame());
+		if(fileType == 1) {
+			data = format::VideoBufferToBMP(screenshot);
+		} else if(fileType == 2) {
+			data = format::VideoBufferToPPM(screenshot);
+		} else {
 			data = format::VideoBufferToPNG(screenshot);
 		}
 	}
 	std::stringstream filename;
 	filename << "screenshot_";
 	filename << std::setfill('0') << std::setw(6) << (screenshotIndex++);
-	if(fileType) { filename << ".ppm"; }
-	else { filename << ".png"; }
+	if(fileType == 1) {
+		filename << ".bmp";
+	} else if(fileType == 2) {
+		filename << ".ppm";
+	} else {
+		filename << ".png";
+	}
 	Client::Ref().WriteFile(data, filename.str());
 	lua_pushstring(l, filename.str().c_str());
 	return 1;


### PR DESCRIPTION
Extended tpt.screenshot to support selecting a file type
Added in BMP support for VideoBuffer conversions.
