### PR TITLE
The element ERAY

### DIFF
--- a/src/cat/LuaScriptInterface.cpp
+++ b/src/cat/LuaScriptInterface.cpp
@@ -33,6 +33,9 @@
 #include "LuaSlider.h"
 #include "LuaProgressBar.h"
 
+// ERAY defines some useful bitmasks
+#include "simulation/elements/ERAY.h"
+
 #ifndef WIN
 #include <unistd.h>
 #endif
@@ -1869,6 +1872,20 @@ void LuaScriptInterface::initElementsAPI()
 	SETCONST(l, SC_LIFE);
 	SETCONST(l, SC_TOOL);
 	SETCONST(l, SC_DECO);
+
+	// expose ERAY bit variables for convenience
+	SETCONST(l, ERAY_TYPE_BIT);
+	SETCONST(l, ERAY_LIFE_BIT);
+	SETCONST(l, ERAY_CTYPE_BIT);
+	SETCONST(l, ERAY_X_BIT);
+	SETCONST(l, ERAY_Y_BIT);
+	SETCONST(l, ERAY_VX_BIT);
+	SETCONST(l, ERAY_VY_BIT);
+	SETCONST(l, ERAY_TEMP_BIT);
+	SETCONST(l, ERAY_FLAGS_BIT);
+	SETCONST(l, ERAY_TMP_BIT);
+	SETCONST(l, ERAY_TMP2_BIT);
+	SETCONST(l, ERAY_DCOLOUR_BIT);
 
 	//Element identifiers
 	for(int i = 0; i < PT_NUM; i++)

--- a/src/simulation/Simulation.cpp
+++ b/src/simulation/Simulation.cpp
@@ -1886,6 +1886,8 @@ void Simulation::clear_sim(void)
 	memset(wireless, 0, sizeof(wireless));
 	memset(gol2, 0, sizeof(gol2));
 	memset(portalp, 0, sizeof(portalp));
+	// Reset ERAY array if sim is cleared
+	memset(erays, 0, sizeof(erays));
 	memset(fighters, 0, sizeof(fighters));
 	std::fill(elementCount, elementCount+PT_NUM, 0);
 	elementRecount = true;

--- a/src/simulation/Simulation.h
+++ b/src/simulation/Simulation.h
@@ -69,6 +69,8 @@ public:
 	bool gravWallChanged;
 	//Portals and Wifi
 	Particle portalp[CHANNELS][8][80];
+	// ERAY data
+	Particle erays[100];
 	int portal_rx[8];
 	int portal_ry[8];
 	int wireless[CHANNELS][2];

--- a/src/simulation/elements/ERAY.cpp
+++ b/src/simulation/elements/ERAY.cpp
@@ -1,0 +1,215 @@
+#include "simulation/Elements.h"
+
+/*
+  ERAY  The Element Property Ray (PRAY)
+  ====
+
+  The Element that turns Children into Adults
+  The Element that turns DUST into exploding SING
+  The Element that turns your bomb into a feeble nothing
+  The Element that makes your self-replicator work
+
+  Powered by bit strings and a hundred-long Particle array in Simulation.cpp.
+
+  HOW TO USE
+  === == ===
+
+  1. Write the fancy bit string for the element
+     ( Add up the #defines you want from ERAY.h, 
+       or run `bit.bor(elem.ERAY_TYPE_BIT, ...)` ) and set that as TMP.
+
+  1.5 Select one of the 100 available slots for your copied element and 
+      set the pixel's TMP2 to the slot - 1. (so 0, 1, ..., 98, 99 are valid)
+
+  2. Spark it with PSCN to fire a beam to copy all properties of anything hit.
+  3. Spark it with any other metal to fire a beam and paste the properties you 
+     have set.
+
+  * Unknown behavior when sparked with 'any other metal' before cloning.
+  * Bit string defaults to ERAY_TYPE_BIT|ERAY_LIFE_BIT|ERAY_CTYPE_BIT
+  
+  WHAT IT DOES
+  ==== == ====
+
+  It's like portable PROP. 
+
+  by boxmein I suppose 
+*/
+
+#include "ERAY.h"
+
+//#TPT-Directive ElementClass Element_ERAY PT_ERAY 177
+Element_ERAY::Element_ERAY()
+{
+  Identifier = "DEFAULT_PT_ERAY";
+  Name = "ERAY";
+  Colour = PIXPACK(0xFFEE33);
+  MenuVisible = 1;
+  MenuSection = SC_ELEC;
+  Enabled = 1;
+  
+  Advection = 0.0f;
+  AirDrag = 0.00f * CFDS;
+  AirLoss = 0.90f;
+  Loss = 0.00f;
+  Collision = 0.0f;
+  Gravity = 0.0f;
+  Diffusion = 0.00f;
+  HotAir = 0.000f * CFDS;
+  Falldown = 0;
+  
+  Flammable = 0;
+  Explosive = 0;
+  Meltable = 0;
+  Hardness = 1;
+  
+  Weight = 100;
+  
+  Temperature = R_TEMP+0.0f +273.15f;
+  HeatConduct = 0;
+  Description = "Element Ray. Sets properties on other elements.";
+  
+  State = ST_SOLID;
+  Properties = TYPE_SOLID|PROP_LIFE_DEC;
+  
+  LowPressure = IPL;
+  LowPressureTransition = NT;
+  HighPressure = IPH;
+  HighPressureTransition = NT;
+  LowTemperature = ITL;
+  LowTemperatureTransition = NT;
+  HighTemperature = ITH;
+  HighTemperatureTransition = NT;
+  
+  Update = &Element_ERAY::update;
+  
+}
+
+//#TPT-Directive ElementHeader Element_ERAY static int update(UPDATE_FUNC_ARGS)
+int Element_ERAY::update(UPDATE_FUNC_ARGS)
+ {
+  int q, r, nxx, nyy, docontinue, nxi, nyi, rx, ry, nr, ry1, rx1;
+
+  // the usual
+  for (rx=-1; rx<2; rx++)
+    for (ry=-1; ry<2; ry++)
+      if (BOUNDS_CHECK && (rx || ry))
+      {
+        r = pmap[y+ry][x+rx];
+        if (!r)
+          continue;
+
+        if ((r&0xFF)==PT_SPRK && parts[r>>8].life==3) {
+
+          // draw a BRAY hint beam
+          for (docontinue = 1, nxx = 0, nyy = 0, nxi = rx*-1, nyi = ry*-1; docontinue; nyy+=nyi, nxx+=nxi) {
+            if (!(x+nxi+nxx<XRES && y+nyi+nyy<YRES && x+nxi+nxx >= 0 && y+nyi+nyy >= 0)) {
+              break;
+            }
+            q = pmap[y+nyi+nyy][x+nxi+nxx];
+            if (!q) {
+              int nr = sim->create_part(-1, x+nxi+nxx, y+nyi+nyy, PT_BRAY);
+              if (nr!=-1) {
+                parts[nr].life = 7;
+              }
+            }
+            else {
+              // woo we hit something!
+
+              // set own properties when sparked with PSCN
+              // else set others' properties
+              if (parts[r>>8].ctype==PT_PSCN) {
+
+                // lol, invalid erays[] reference
+                if (parts[i].tmp2 < 0) {
+                  parts[i].tmp2 = 0;
+                  continue;
+                }
+                else if (parts[i].tmp2 > 99) {
+                  parts[i].tmp2 = 99;
+                  continue;
+                }
+
+                // Copy over any property we care of
+                sim->erays[ parts[i].tmp2 ].type    = parts[ q>>8 ].type;
+                sim->erays[ parts[i].tmp2 ].life    = parts[ q>>8 ].life;
+                sim->erays[ parts[i].tmp2 ].ctype   = parts[ q>>8 ].ctype;
+                sim->erays[ parts[i].tmp2 ].x       = parts[ q>>8 ].x;
+                sim->erays[ parts[i].tmp2 ].y       = parts[ q>>8 ].y;
+                sim->erays[ parts[i].tmp2 ].vx      = parts[ q>>8 ].vx;
+                sim->erays[ parts[i].tmp2 ].vy      = parts[ q>>8 ].vy;
+                sim->erays[ parts[i].tmp2 ].temp    = parts[ q>>8 ].temp;
+                sim->erays[ parts[i].tmp2 ].flags   = parts[ q>>8 ].flags;
+                sim->erays[ parts[i].tmp2 ].tmp     = parts[ q>>8 ].tmp;
+                sim->erays[ parts[i].tmp2 ].tmp2    = parts[ q>>8 ].tmp2;
+                sim->erays[ parts[i].tmp2 ].dcolour = parts[ q>>8 ].dcolour;
+
+                docontinue = 0;
+                
+              } else {
+                // whoops what do I copy to
+                if (parts[i].tmp==0) 
+                  parts[i].tmp = ERAY_TYPE_BIT|ERAY_LIFE_BIT|ERAY_CTYPE_BIT;
+
+                // lol, invalid erays[] reference
+                if (parts[i].tmp2 < 0) {
+                  parts[i].tmp2 = 0;
+                  continue;
+                }
+                else if (parts[i].tmp2 > 99) {
+                  parts[i].tmp2 = 99;
+                  continue;
+                }
+
+                // give away what specified
+                if (parts[i].tmp&ERAY_TYPE_BIT)
+                  parts[q>>8].type = sim->erays[parts[i].tmp2].type;
+
+                if (parts[i].tmp&ERAY_LIFE_BIT)
+                  parts[q>>8].life = sim->erays[parts[i].tmp2].life;
+
+                if (parts[i].tmp&ERAY_CTYPE_BIT)
+                  parts[q>>8].ctype = sim->erays[parts[i].tmp2].ctype;
+
+                if (parts[i].tmp&ERAY_X_BIT)
+                  parts[q>>8].x = sim->erays[parts[i].tmp2].x;
+
+                if (parts[i].tmp&ERAY_Y_BIT)
+                  parts[q>>8].y = sim->erays[parts[i].tmp2].y;
+
+                if (parts[i].tmp&ERAY_VX_BIT)
+                  parts[q>>8].vx = sim->erays[parts[i].tmp2].vx;
+
+                if (parts[i].tmp&ERAY_VY_BIT)
+                  parts[q>>8].vy = sim->erays[parts[i].tmp2].vy;
+
+                if (parts[i].tmp&ERAY_TEMP_BIT)
+                  parts[q>>8].temp = sim->erays[parts[i].tmp2].temp;
+
+                if (parts[i].tmp&ERAY_FLAGS_BIT)
+                  parts[q>>8].flags = sim->erays[parts[i].tmp2].flags;
+
+                if (parts[i].tmp&ERAY_TMP_BIT)
+                  parts[q>>8].tmp = sim->erays[parts[i].tmp2].tmp;
+
+                if (parts[i].tmp&ERAY_TMP2_BIT)
+                  parts[q>>8].tmp2 = sim->erays[parts[i].tmp2].tmp2;
+
+                if (parts[i].tmp&ERAY_DCOLOUR_BIT)
+                  parts[q>>8].dcolour = sim->erays[parts[i].tmp2].dcolour;
+
+                docontinue = 0;
+              }
+            }
+          }
+
+
+        }
+      }
+    //
+  //
+  return 0;
+}
+
+
+Element_ERAY::~Element_ERAY() {}

--- a/src/simulation/elements/ERAY.h
+++ b/src/simulation/elements/ERAY.h
@@ -1,0 +1,15 @@
+
+// List of bitmasks ERAY can copy
+
+#define ERAY_TYPE_BIT 1
+#define ERAY_LIFE_BIT 2
+#define ERAY_CTYPE_BIT 4
+#define ERAY_X_BIT 8
+#define ERAY_Y_BIT 16
+#define ERAY_VX_BIT 32
+#define ERAY_VY_BIT 64
+#define ERAY_TEMP_BIT 128
+#define ERAY_FLAGS_BIT 256
+#define ERAY_TMP_BIT 512
+#define ERAY_TMP2_BIT 1024
+#define ERAY_DCOLOUR_BIT 2048


### PR DESCRIPTION
### ERAY

_The Element Property Ray (PRAY)_

The Element that turns Children into Adults
The Element that turns DUST into exploding SING
The Element that turns your bomb into a feeble nothing
The Element that makes your self-replicator work
Powered by bit strings and a hundred-long Particle array in Simulation.cpp.
#### How to use
1. Either: use the **default values of copying type, life and ctype**, or write the fancy bit string for the element ( Add up the #define codes you want from src/simulation/elements/ERAY.h, or run `bit.bor(elem.ERAY_TYPE_BIT, ...)` in the lua console) and set that as TMP. Arguably the hardest part of using the element. Existing ERAY can be used to apply tmp-strings though. In some _farther_ future an UI could be created...
2.  Select one of the 100 available slots (0 to 99) for your copied element and set the pixel's TMP2 to the slot number. This is a simple way to have two ERAYs using the same particle data as well as making the implementation not modify existing structures _too_ much.
3. Spark it with PSCN to fire a beam to copy all properties of anything hit. This is a kind of intuitive way of saving the properties of an element - create one first, then set values to it.
4. Spark it with any other metal (like METL) to fire a beam, hitting some other particle and setting its properties as desired.
- Unknown behavior when sparked with 'any other metal' before cloning. Alternatively, deleting behavior, depending on how the particles[] ends up being initialized.
- If the tmp2 upon firing a beam is 0, the element will set its tmp to `ERAY_TYPE_BIT | ERAY_LIFE_BIT | ERAY_CTYPE_BIT`
