### PR TITLE
Prevent users from setting random .tmp and .tmp2 values for some sensors.

### DIFF
--- a/src/simulation/elements/DTEC.cpp
+++ b/src/simulation/elements/DTEC.cpp
@@ -48,7 +48,10 @@ Element_DTEC::Element_DTEC()
 int Element_DTEC::update(UPDATE_FUNC_ARGS)
 {
 	int r, rx, ry, rt, rd = parts[i].tmp2;
-	(rd > 25 || rd < 0) parts[i].tmp2 = rd = 25;
+	if (rd > 25 || rd < 0)
+	{
+		parts[i].tmp2 = rd = 25;
+	}
 	if (parts[i].life)
 	{
 		parts[i].life = 0;

--- a/src/simulation/elements/DTEC.cpp
+++ b/src/simulation/elements/DTEC.cpp
@@ -48,7 +48,7 @@ Element_DTEC::Element_DTEC()
 int Element_DTEC::update(UPDATE_FUNC_ARGS)
 {
 	int r, rx, ry, rt, rd = parts[i].tmp2;
-	if (rd > 25) parts[i].tmp2 = rd = 25;
+	(rd > 25 || rd < 0) parts[i].tmp2 = rd = 25;
 	if (parts[i].life)
 	{
 		parts[i].life = 0;

--- a/src/simulation/elements/LSNS.cpp
+++ b/src/simulation/elements/LSNS.cpp
@@ -48,7 +48,7 @@ Element_LSNS::Element_LSNS()
 int Element_LSNS::update(UPDATE_FUNC_ARGS)
 {
 	int r, rx, ry, rt, rd = parts[i].tmp2;
-	if (rd > 25) parts[i].tmp2 = rd = 25;
+	if (rd > 25 || rd < 0) parts[i].tmp2 = rd = 25;
 	if (parts[i].life)
 	{
 		parts[i].life = 0;
@@ -146,7 +146,11 @@ int Element_LSNS::update(UPDATE_FUNC_ARGS)
 					}
 				}
 			}
-
+	//Preventing user from setting random .tmp values.
+	if (parts[i].tmp > 3 || parts[i].tmp < 0)
+	{
+		parts[i].tmp = 0;
+	}
 	return 0;
 
 }

--- a/src/simulation/elements/LSNS.cpp
+++ b/src/simulation/elements/LSNS.cpp
@@ -48,7 +48,10 @@ Element_LSNS::Element_LSNS()
 int Element_LSNS::update(UPDATE_FUNC_ARGS)
 {
 	int r, rx, ry, rt, rd = parts[i].tmp2;
-	if (rd > 25 || rd < 0) parts[i].tmp2 = rd = 25;
+	if (rd > 25 || rd < 0)
+	{
+		parts[i].tmp2 = rd = 25;
+	}
 	if (parts[i].life)
 	{
 		parts[i].life = 0;

--- a/src/simulation/elements/PSNS.cpp
+++ b/src/simulation/elements/PSNS.cpp
@@ -99,6 +99,11 @@ int Element_PSNS::update(UPDATE_FUNC_ARGS)
 					}
 		}
 	}
+	//Preventing user from setting random .tmp values.
+	if (parts[i].tmp > 2 || parts[i].tmp < 0)
+	{
+		parts[i].tmp = 0;
+	}
 	return 0;
 }
 

--- a/src/simulation/elements/TSNS.cpp
+++ b/src/simulation/elements/TSNS.cpp
@@ -48,8 +48,10 @@ Element_TSNS::Element_TSNS()
 int Element_TSNS::update(UPDATE_FUNC_ARGS)
 {
 	int rd = parts[i].tmp2;
-	(rd > 25 || rd < 0)
+	if (rd > 25 || rd < 0)
+	{
 		parts[i].tmp2 = rd = 25;
+	}
 	if (parts[i].life)
 	{
 		parts[i].life = 0;

--- a/src/simulation/elements/TSNS.cpp
+++ b/src/simulation/elements/TSNS.cpp
@@ -48,7 +48,7 @@ Element_TSNS::Element_TSNS()
 int Element_TSNS::update(UPDATE_FUNC_ARGS)
 {
 	int rd = parts[i].tmp2;
-	if (rd > 25)
+	(rd > 25 || rd < 0)
 		parts[i].tmp2 = rd = 25;
 	if (parts[i].life)
 	{
@@ -115,6 +115,11 @@ int Element_TSNS::update(UPDATE_FUNC_ARGS)
 						r = pmap[ny][nx];
 					}
 				}
+	}
+	//Preventing user from setting random .tmp values.
+	if (parts[i].tmp > 2 || parts[i].tmp < 0)
+	{
+		parts[i].tmp = 0;
 	}
 	return 0;
 }


### PR DESCRIPTION
Leaving out DTEC and LDTC for now (first need to move .tmp into .ctype)