### PR TITLE
Allows to change menu item selection from hovering to mouse click

### DIFF
--- a/src/gui/game/GameController.cpp
+++ b/src/gui/game/GameController.cpp
@@ -1781,3 +1781,8 @@ void GameController::RunUpdater()
 	Platform::OpenURI(file);
 #endif // MACOSX
 }
+
+bool GameController::GetMouseClickRequired()
+{
+	return gameModel->GetMouseClickRequired();
+}

--- a/src/gui/game/GameController.h
+++ b/src/gui/game/GameController.h
@@ -177,6 +177,7 @@ public:
 	void NotifyAuthUserChanged(Client * sender) override;
 	void NotifyNewNotification(Client * sender, std::pair<String, ByteString> notification) override;
 	void RunUpdater();
+	bool GetMouseClickRequired();
 };
 
 #endif // GAMECONTROLLER_H

--- a/src/gui/game/GameModel.cpp
+++ b/src/gui/game/GameModel.cpp
@@ -1307,5 +1307,4 @@ bool GameModel::GetMouseClickRequired()
 void GameModel::SetMouseClickRequired(bool mouseClickRequired_)
 {
 	mouseClickRequired = mouseClickRequired_;
-	notifyMenuListChanged();
 }

--- a/src/gui/game/GameModel.cpp
+++ b/src/gui/game/GameModel.cpp
@@ -153,6 +153,8 @@ GameModel::GameModel():
 	// cap due to memory usage (this is about 3.4GB of RAM)
 	if (undoHistoryLimit > 200)
 		undoHistoryLimit = 200;
+
+	mouseClickRequired = Client::Ref().GetPrefBool("MouseClickRequired", false);
 }
 
 GameModel::~GameModel()
@@ -181,6 +183,8 @@ GameModel::~GameModel()
 	Client::Ref().SetPref("Decoration.Alpha", (int)colour.Alpha);
 
 	Client::Ref().SetPref("Simulation.UndoHistoryLimit", undoHistoryLimit);
+
+	Client::Ref().SetPref("MouseClickRequired", mouseClickRequired);
 
 	Favorite::Ref().SaveFavoritesToPrefs();
 
@@ -1293,4 +1297,15 @@ void GameModel::notifyLastToolChanged()
 	{
 		observers[i]->NotifyLastToolChanged(this);
 	}
+}
+
+bool GameModel::GetMouseClickRequired()
+{
+	return mouseClickRequired;
+}
+
+void GameModel::SetMouseClickRequired(bool mouseClickRequired_)
+{
+	mouseClickRequired = mouseClickRequired_;
+	notifyMenuListChanged();
 }

--- a/src/gui/game/GameModel.h
+++ b/src/gui/game/GameModel.h
@@ -67,6 +67,7 @@ private:
 	Snapshot *redoHistory;
 	unsigned int historyPosition;
 	unsigned int undoHistoryLimit;
+	bool mouseClickRequired;
 
 	size_t activeColourPreset;
 	std::vector<ui::Colour> colourPresets;
@@ -202,6 +203,8 @@ public:
 	std::deque<String> GetLog();
 	GameSave * GetClipboard();
 	GameSave * GetPlaceSave();
+	bool GetMouseClickRequired();
+	void SetMouseClickRequired(bool mouseClickRequired_);
 
 	std::vector<Notification*> GetNotifications();
 	void AddNotification(Notification * notification);

--- a/src/gui/game/GameView.cpp
+++ b/src/gui/game/GameView.cpp
@@ -492,10 +492,10 @@ public:
 	{
 		v = _v;
 		menuID = menuID_;
-		if (menuID == SC_DECO)
+		 if (menuID == SC_DECO)
 			needsClick = true;
 		else
-			needsClick = false;
+			needsClick = v->c->GetMouseClickRequired();
 	}
 	void MouseEnterCallback(ui::Button * sender) override
 	{

--- a/src/gui/game/GameView.cpp
+++ b/src/gui/game/GameView.cpp
@@ -495,19 +495,19 @@ public:
 		 if (menuID == SC_DECO)
 			needsClick = true;
 		else
-			needsClick = v->c->GetMouseClickRequired();
+			needsClick = false;
 	}
 	void MouseEnterCallback(ui::Button * sender) override
 	{
 		// don't immediately change the active menu, the actual set is done inside GameView::OnMouseMove
 		// if we change it here it causes components to be removed, which causes the window to stop sending events
 		// and then the previous menusection button never gets sent the OnMouseLeave event and is never unhighlighted
-		if(!needsClick && !v->GetMouseDown())
+		if(!(needsClick || v->c->GetMouseClickRequired()) && !v->GetMouseDown())
 			v->SetActiveMenuDelayed(menuID);
 	}
 	void ActionCallback(ui::Button * sender) override
 	{
-		if (needsClick)
+		if (needsClick || v->c->GetMouseClickRequired())
 			v->c->SetActiveMenu(menuID);
 		else
 			MouseEnterCallback(sender);

--- a/src/gui/options/OptionsController.cpp
+++ b/src/gui/options/OptionsController.cpp
@@ -92,6 +92,11 @@ OptionsView * OptionsController::GetView()
 	return view;
 }
 
+void OptionsController::SetMouseClickrequired(bool mouseClickRequired)
+{
+	model->SetMouseClickRequired(mouseClickRequired);
+}
+
 void OptionsController::Exit()
 {
 	view->CloseActiveWindow();

--- a/src/gui/options/OptionsController.h
+++ b/src/gui/options/OptionsController.h
@@ -28,6 +28,8 @@ public:
 	void SetResizable(bool resizable);
 	void SetFastQuit(bool fastquit);
 	void SetShowAvatars(bool showAvatars);
+	void SetMouseClickrequired(bool mouseClickRequired);
+	
 	void Exit();
 	OptionsView * GetView();
 	virtual ~OptionsController();

--- a/src/gui/options/OptionsModel.cpp
+++ b/src/gui/options/OptionsModel.cpp
@@ -180,6 +180,18 @@ void OptionsModel::SetShowAvatars(bool state)
 	notifySettingsChanged();
 }
 
+bool OptionsModel::GetMouseClickRequired()
+{
+	return Client::Ref().GetPrefBool("MouseClickRequired", false);
+}
+
+void OptionsModel::SetMouseClickRequired(bool mouseClickRequired)
+{
+	Client::Ref().SetPref("MouseClickRequired", mouseClickRequired);
+	gModel->SetMouseClickRequired(mouseClickRequired);
+	notifySettingsChanged();
+}
+
 void OptionsModel::notifySettingsChanged()
 {
 	for (size_t i = 0; i < observers.size(); i++)

--- a/src/gui/options/OptionsModel.h
+++ b/src/gui/options/OptionsModel.h
@@ -43,6 +43,8 @@ public:
 	void SetForceIntegerScaling(bool forceIntegerScaling);
 	bool GetFastQuit();
 	void SetFastQuit(bool fastquit);
+	bool GetMouseClickRequired();
+	void SetMouseClickRequired(bool mouseClickRequired);
 	virtual ~OptionsModel();
 };
 

--- a/src/gui/options/OptionsView.cpp
+++ b/src/gui/options/OptionsView.cpp
@@ -23,12 +23,18 @@
 #include "graphics/Graphics.h"
 
 OptionsView::OptionsView():
-	ui::Window(ui::Point(-1, -1), ui::Point(300, 389)){
+	ui::Window(ui::Point(-1, -1), ui::Point(350, 389)){
+
+	int currentY = 400;
+	scrollPanel = new ui::ScrollPanel(ui::Point(-1, -1), ui::Point(Size.X, Size.Y-16));
+	
+	AddComponent(scrollPanel);
 
 	ui::Label * tempLabel = new ui::Label(ui::Point(4, 5), ui::Point(Size.X-8, 14), "Simulation Options");
 	tempLabel->SetTextColour(style::Colour::InformationTitle);
 	tempLabel->Appearance.HorizontalAlign = ui::Appearance::AlignLeft;	tempLabel->Appearance.VerticalAlign = ui::Appearance::AlignMiddle;
-	AddComponent(tempLabel);
+	scrollPanel->AddChild(tempLabel);
+	
 
 	class HeatSimulationAction: public ui::CheckboxAction
 	{
@@ -42,10 +48,10 @@ OptionsView::OptionsView():
 
 	heatSimulation = new ui::Checkbox(ui::Point(8, 23), ui::Point(Size.X-6, 16), "Heat simulation \bgIntroduced in version 34", "");
 	heatSimulation->SetActionCallback(new HeatSimulationAction(this));
-	AddComponent(heatSimulation);
+	scrollPanel->AddChild(heatSimulation);
 	tempLabel = new ui::Label(ui::Point(24, heatSimulation->Position.Y+14), ui::Point(Size.X-28, 16), "\bgCan cause odd behaviour when disabled");
 	tempLabel->Appearance.HorizontalAlign = ui::Appearance::AlignLeft;	tempLabel->Appearance.VerticalAlign = ui::Appearance::AlignMiddle;
-	AddComponent(tempLabel);
+	scrollPanel->AddChild(tempLabel);
 
 	class AmbientHeatSimulationAction: public ui::CheckboxAction
 	{
@@ -59,10 +65,10 @@ OptionsView::OptionsView():
 
 	ambientHeatSimulation = new ui::Checkbox(ui::Point(8, 53), ui::Point(Size.X-6, 16), "Ambient heat simulation \bgIntroduced in version 50", "");
 	ambientHeatSimulation->SetActionCallback(new AmbientHeatSimulationAction(this));
-	AddComponent(ambientHeatSimulation);
+	scrollPanel->AddChild(ambientHeatSimulation);
 	tempLabel = new ui::Label(ui::Point(24, ambientHeatSimulation->Position.Y+14), ui::Point(Size.X-28, 16), "\bgCan cause odd / broken behaviour with many saves");
 	tempLabel->Appearance.HorizontalAlign = ui::Appearance::AlignLeft;	tempLabel->Appearance.VerticalAlign = ui::Appearance::AlignMiddle;
-	AddComponent(tempLabel);
+	scrollPanel->AddChild(tempLabel);
 
 	class NewtonianGravityAction: public ui::CheckboxAction
 	{
@@ -76,10 +82,10 @@ OptionsView::OptionsView():
 
 	newtonianGravity = new ui::Checkbox(ui::Point(8, 83), ui::Point(Size.X-6, 16), "Newtonian gravity \bgIntroduced in version 48", "");
 	newtonianGravity->SetActionCallback(new NewtonianGravityAction(this));
-	AddComponent(newtonianGravity);
+	scrollPanel->AddChild(newtonianGravity);
 	tempLabel = new ui::Label(ui::Point(24, newtonianGravity->Position.Y+14), ui::Point(Size.X-28, 16), "\bgMay cause poor performance on older computers");
 	tempLabel->Appearance.HorizontalAlign = ui::Appearance::AlignLeft;	tempLabel->Appearance.VerticalAlign = ui::Appearance::AlignMiddle;
-	AddComponent(tempLabel);
+	scrollPanel->AddChild(tempLabel);
 
 	class WaterEqualisationAction: public ui::CheckboxAction
 		{
@@ -93,10 +99,10 @@ OptionsView::OptionsView():
 
 	waterEqualisation = new ui::Checkbox(ui::Point(8, 113), ui::Point(Size.X-6, 16), "Water equalisation \bgIntroduced in version 61", "");
 	waterEqualisation->SetActionCallback(new WaterEqualisationAction(this));
-	AddComponent(waterEqualisation);
+	scrollPanel->AddChild(waterEqualisation);
 	tempLabel = new ui::Label(ui::Point(24, waterEqualisation->Position.Y+14), ui::Point(Size.X-28, 16), "\bgMay cause poor performance with a lot of water");
 	tempLabel->Appearance.HorizontalAlign = ui::Appearance::AlignLeft;	tempLabel->Appearance.VerticalAlign = ui::Appearance::AlignMiddle;
-	AddComponent(tempLabel);
+	scrollPanel->AddChild(tempLabel);
 
 	class AirModeChanged: public ui::DropDownAction
 	{
@@ -108,7 +114,7 @@ OptionsView::OptionsView():
 		}
 	};
 	airMode = new ui::DropDown(ui::Point(Size.X-88, 146), ui::Point(80, 16));
-	AddComponent(airMode);
+	scrollPanel->AddChild(airMode);
 	airMode->AddOption(std::pair<String, int>("On", 0));
 	airMode->AddOption(std::pair<String, int>("Pressure off", 1));
 	airMode->AddOption(std::pair<String, int>("Velocity off", 2));
@@ -118,7 +124,7 @@ OptionsView::OptionsView():
 
 	tempLabel = new ui::Label(ui::Point(8, 146), ui::Point(Size.X-96, 16), "Air Simulation Mode");
 	tempLabel->Appearance.HorizontalAlign = ui::Appearance::AlignLeft;	tempLabel->Appearance.VerticalAlign = ui::Appearance::AlignMiddle;
-	AddComponent(tempLabel);
+	scrollPanel->AddChild(tempLabel);
 
 	class GravityModeChanged: public ui::DropDownAction
 	{
@@ -131,7 +137,7 @@ OptionsView::OptionsView():
 	};
 
 	gravityMode = new ui::DropDown(ui::Point(Size.X-88, 166), ui::Point(80, 16));
-	AddComponent(gravityMode);
+	scrollPanel->AddChild(gravityMode);
 	gravityMode->AddOption(std::pair<String, int>("Vertical", 0));
 	gravityMode->AddOption(std::pair<String, int>("Off", 1));
 	gravityMode->AddOption(std::pair<String, int>("Radial", 2));
@@ -139,7 +145,7 @@ OptionsView::OptionsView():
 
 	tempLabel = new ui::Label(ui::Point(8, 166), ui::Point(Size.X-96, 16), "Gravity Simulation Mode");
 	tempLabel->Appearance.HorizontalAlign = ui::Appearance::AlignLeft;	tempLabel->Appearance.VerticalAlign = ui::Appearance::AlignMiddle;
-	AddComponent(tempLabel);
+	scrollPanel->AddChild(tempLabel);
 
 	class EdgeModeChanged: public ui::DropDownAction
 	{
@@ -152,7 +158,7 @@ OptionsView::OptionsView():
 	};
 
 	edgeMode = new ui::DropDown(ui::Point(Size.X-88, 186), ui::Point(80, 16));
-	AddComponent(edgeMode);
+	scrollPanel->AddChild(edgeMode);
 	edgeMode->AddOption(std::pair<String, int>("Void", 0));
 	edgeMode->AddOption(std::pair<String, int>("Solid", 1));
 	edgeMode->AddOption(std::pair<String, int>("Loop", 2));
@@ -160,7 +166,7 @@ OptionsView::OptionsView():
 
 	tempLabel = new ui::Label(ui::Point(8, 186), ui::Point(Size.X-96, 16), "Edge Mode");
 	tempLabel->Appearance.HorizontalAlign = ui::Appearance::AlignLeft;	tempLabel->Appearance.VerticalAlign = ui::Appearance::AlignMiddle;
-	AddComponent(tempLabel);
+	scrollPanel->AddChild(tempLabel);
 
 	class ScaleAction: public ui::DropDownAction
 	{
@@ -188,11 +194,11 @@ OptionsView::OptionsView():
 			scale->AddOption(std::pair<String, int>("current", current_scale));
 	}
 	scale->SetActionCallback(new ScaleAction(this));
-	AddComponent(scale);
+	scrollPanel->AddChild(scale);
 
 	tempLabel = new ui::Label(ui::Point(scale->Position.X+scale->Size.X+3, scale->Position.Y), ui::Point(Size.X-28, 16), "\bg- Window scale factor for larger screens");
 	tempLabel->Appearance.HorizontalAlign = ui::Appearance::AlignLeft;	tempLabel->Appearance.VerticalAlign = ui::Appearance::AlignMiddle;
-	AddComponent(tempLabel);
+	scrollPanel->AddChild(tempLabel);
 
 
 	class ResizableAction: public ui::CheckboxAction
@@ -210,8 +216,8 @@ OptionsView::OptionsView():
 	resizable->SetActionCallback(new ResizableAction(this));
 	tempLabel = new ui::Label(ui::Point(resizable->Position.X+Graphics::textwidth(resizable->GetText().c_str())+20, resizable->Position.Y), ui::Point(Size.X-28, 16), "\bg- Allow resizing and maximizing window");
 	tempLabel->Appearance.HorizontalAlign = ui::Appearance::AlignLeft;	tempLabel->Appearance.VerticalAlign = ui::Appearance::AlignMiddle;
-	AddComponent(tempLabel);
-	AddComponent(resizable);
+	scrollPanel->AddChild(tempLabel);
+	scrollPanel->AddChild(resizable);
 
 	class FullscreenAction: public ui::CheckboxAction
 	{
@@ -228,8 +234,8 @@ OptionsView::OptionsView():
 	fullscreen->SetActionCallback(new FullscreenAction(this));
 	tempLabel = new ui::Label(ui::Point(fullscreen->Position.X+Graphics::textwidth(fullscreen->GetText().c_str())+20, fullscreen->Position.Y), ui::Point(Size.X-28, 16), "\bg- Fill the entire screen");
 	tempLabel->Appearance.HorizontalAlign = ui::Appearance::AlignLeft;	tempLabel->Appearance.VerticalAlign = ui::Appearance::AlignMiddle;
-	AddComponent(tempLabel);
-	AddComponent(fullscreen);
+	scrollPanel->AddChild(tempLabel);
+	scrollPanel->AddChild(fullscreen);
 
 	class AltFullscreenAction: public ui::CheckboxAction
 	{
@@ -246,8 +252,8 @@ OptionsView::OptionsView():
 	altFullscreen->SetActionCallback(new AltFullscreenAction(this));
 	tempLabel = new ui::Label(ui::Point(altFullscreen->Position.X+Graphics::textwidth(altFullscreen->GetText().c_str())+20, altFullscreen->Position.Y), ui::Point(Size.X-28, 16), "\bg- Set optimial screen resolution");
 	tempLabel->Appearance.HorizontalAlign = ui::Appearance::AlignLeft;	tempLabel->Appearance.VerticalAlign = ui::Appearance::AlignMiddle;
-	AddComponent(tempLabel);
-	AddComponent(altFullscreen);
+	scrollPanel->AddChild(tempLabel);
+	scrollPanel->AddChild(altFullscreen);
 
 	class ForceIntegerScalingAction: public ui::CheckboxAction
 	{
@@ -264,8 +270,8 @@ OptionsView::OptionsView():
 	forceIntegerScaling->SetActionCallback(new ForceIntegerScalingAction(this));
 	tempLabel = new ui::Label(ui::Point(altFullscreen->Position.X+Graphics::textwidth(forceIntegerScaling->GetText().c_str())+20, forceIntegerScaling->Position.Y), ui::Point(Size.X-28, 16), "\bg- less blurry");
 	tempLabel->Appearance.HorizontalAlign = ui::Appearance::AlignLeft;	tempLabel->Appearance.VerticalAlign = ui::Appearance::AlignMiddle;
-	AddComponent(tempLabel);
-	AddComponent(forceIntegerScaling);
+	scrollPanel->AddChild(tempLabel);
+	scrollPanel->AddChild(forceIntegerScaling);
 
 
 	class FastQuitAction: public ui::CheckboxAction
@@ -282,8 +288,8 @@ OptionsView::OptionsView():
 	fastquit->SetActionCallback(new FastQuitAction(this));
 	tempLabel = new ui::Label(ui::Point(fastquit->Position.X+Graphics::textwidth(fastquit->GetText().c_str())+20, fastquit->Position.Y), ui::Point(Size.X-28, 16), "\bg- Always exit completely when hitting close");
 	tempLabel->Appearance.HorizontalAlign = ui::Appearance::AlignLeft;	tempLabel->Appearance.VerticalAlign = ui::Appearance::AlignMiddle;
-	AddComponent(tempLabel);
-	AddComponent(fastquit);
+	scrollPanel->AddChild(tempLabel);
+	scrollPanel->AddChild(fastquit);
 
 	class ShowAvatarsAction: public ui::CheckboxAction
 	{
@@ -299,8 +305,25 @@ OptionsView::OptionsView():
 	showAvatars->SetActionCallback(new ShowAvatarsAction(this));
 	tempLabel = new ui::Label(ui::Point(showAvatars->Position.X+Graphics::textwidth(showAvatars->GetText().c_str())+20, showAvatars->Position.Y), ui::Point(Size.X-28, 16), "\bg- Disable if you have a slow connection");
 	tempLabel->Appearance.HorizontalAlign = ui::Appearance::AlignLeft;	tempLabel->Appearance.VerticalAlign = ui::Appearance::AlignMiddle;
-	AddComponent(tempLabel);
-	AddComponent(showAvatars);
+	scrollPanel->AddChild(tempLabel);
+	scrollPanel->AddChild(showAvatars);
+
+	class MouseClickRequiredAction: public ui::CheckboxAction
+	{
+		OptionsView * v;
+	public:
+		MouseClickRequiredAction(OptionsView * v_){	v = v_;	}
+		void ActionCallback(ui::Checkbox * sender) override {
+			v->c->SetMouseClickrequired(sender->GetChecked());
+		}
+	};
+
+	mouseClickRequired = new ui::Checkbox(ui::Point(8, showAvatars->Position.Y + 20), ui::Point(Size.X-6, 16), "Mouse click required", "");
+	mouseClickRequired->SetActionCallback(new MouseClickRequiredAction(this));
+	tempLabel = new ui::Label(ui::Point(mouseClickRequired->Position.X+Graphics::textwidth(mouseClickRequired->GetText().c_str())+20, mouseClickRequired->Position.Y), ui::Point(Size.X-28, 16), "\bg- click required to change category in menu");
+	tempLabel->Appearance.HorizontalAlign = ui::Appearance::AlignLeft;	tempLabel->Appearance.VerticalAlign = ui::Appearance::AlignMiddle;
+	scrollPanel->AddChild(tempLabel);
+	scrollPanel->AddChild(mouseClickRequired);
 
 	class DataFolderAction: public ui::ButtonAction
 	{
@@ -323,13 +346,13 @@ OptionsView::OptionsView():
 			delete[] workingDirectory;
 		}
 	};
-	ui::Button * dataFolderButton = new ui::Button(ui::Point(8, Size.Y-38), ui::Point(90, 16), "Open Data Folder");
+	ui::Button * dataFolderButton = new ui::Button(ui::Point(8, mouseClickRequired->Position.Y + 20), ui::Point(90, 16), "Open Data Folder");
 	dataFolderButton->SetActionCallback(new DataFolderAction());
-	AddComponent(dataFolderButton);
+	scrollPanel->AddChild(dataFolderButton);
 
 	tempLabel = new ui::Label(ui::Point(dataFolderButton->Position.X+dataFolderButton->Size.X+3, dataFolderButton->Position.Y), ui::Point(Size.X-28, 16), "\bg- Open the data and preferences folder");
 	tempLabel->Appearance.HorizontalAlign = ui::Appearance::AlignLeft;	tempLabel->Appearance.VerticalAlign = ui::Appearance::AlignMiddle;
-	AddComponent(tempLabel);
+	scrollPanel->AddChild(tempLabel);
 
 	class CloseAction: public ui::ButtonAction
 	{
@@ -347,6 +370,8 @@ OptionsView::OptionsView():
 	AddComponent(tempButton);
 	SetCancelButton(tempButton);
 	SetOkayButton(tempButton);
+
+	scrollPanel->InnerSize = ui::Point(Size.X, currentY);
 }
 
 void OptionsView::NotifySettingsChanged(OptionsModel * sender)
@@ -365,6 +390,7 @@ void OptionsView::NotifySettingsChanged(OptionsModel * sender)
 	forceIntegerScaling->SetChecked(sender->GetForceIntegerScaling());
 	fastquit->SetChecked(sender->GetFastQuit());
 	showAvatars->SetChecked(sender->GetShowAvatars());
+	mouseClickRequired->SetChecked(sender->GetMouseClickRequired());
 }
 
 void OptionsView::AttachController(OptionsController * c_)

--- a/src/gui/options/OptionsView.cpp
+++ b/src/gui/options/OptionsView.cpp
@@ -22,16 +22,36 @@
 #include "graphics/Graphics.h"
 
 OptionsView::OptionsView():
-	ui::Window(ui::Point(-1, -1), ui::Point(320, 389)){
-	
-	ui::Label * tempLabel = new ui::Label(ui::Point(4, 5), ui::Point(Size.X-8, 14), "Simulation Options");
-	tempLabel->SetTextColour(style::Colour::InformationTitle);
-	tempLabel->Appearance.HorizontalAlign = ui::Appearance::AlignLeft;	tempLabel->Appearance.VerticalAlign = ui::Appearance::AlignMiddle;
-	AddComponent(tempLabel);
-	
+	ui::Window(ui::Point(-1, -1), ui::Point(320, 340)){
 
-	int currentY = 10;
-	scrollPanel = new ui::ScrollPanel(ui::Point(1, 17), ui::Point(Size.X-2, Size.Y-33));
+	auto autowidth = [this](ui::Component *c) {
+		c->Size.X = Size.X - c->Position.X - 12;
+	};
+	
+	ui::Label * tempLabel = new ui::Label(ui::Point(4, 1), ui::Point(Size.X-8, 22), "Simulation Options");
+	tempLabel->SetTextColour(style::Colour::InformationTitle);
+	tempLabel->Appearance.HorizontalAlign = ui::Appearance::AlignLeft;
+	tempLabel->Appearance.VerticalAlign = ui::Appearance::AlignMiddle;
+	autowidth(tempLabel);
+	AddComponent(tempLabel);
+
+	class Separator : public ui::Component
+	{
+		public:
+		Separator(ui::Point position, ui::Point size) : Component(position, size){}
+		virtual ~Separator(){}
+
+		void Draw(const ui::Point& screenPos)
+		{
+			GetGraphics()->drawrect(screenPos.X, screenPos.Y, Size.X, Size.Y, 255, 255, 255, 180);
+		}		
+	};
+	
+	Separator *tmpSeparator = new Separator(ui::Point(0, 22), ui::Point(Size.X, 1));
+	AddComponent(tmpSeparator);
+
+	int currentY = 6;
+	scrollPanel = new ui::ScrollPanel(ui::Point(1, 23), ui::Point(Size.X-2, Size.Y-39));
 	
 	AddComponent(scrollPanel);
 
@@ -45,12 +65,15 @@ OptionsView::OptionsView():
 		}
 	};
 
-	heatSimulation = new ui::Checkbox(ui::Point(8, currentY), ui::Point(Size.X-6, 16), "Heat simulation \bgIntroduced in version 34", "");
+	heatSimulation = new ui::Checkbox(ui::Point(8, currentY), ui::Point(1, 16), "Heat simulation \bgIntroduced in version 34", "");
+	autowidth(heatSimulation);
 	heatSimulation->SetActionCallback(new HeatSimulationAction(this));
 	scrollPanel->AddChild(heatSimulation);
 	currentY+=14;
-	tempLabel = new ui::Label(ui::Point(24, currentY), ui::Point(Size.X-28, 16), "\bgCan cause odd behaviour when disabled");
-	tempLabel->Appearance.HorizontalAlign = ui::Appearance::AlignLeft;	tempLabel->Appearance.VerticalAlign = ui::Appearance::AlignMiddle;
+	tempLabel = new ui::Label(ui::Point(24, currentY), ui::Point(1, 16), "\bgCan cause odd behaviour when disabled");
+	autowidth(tempLabel);
+	tempLabel->Appearance.HorizontalAlign = ui::Appearance::AlignLeft;
+	tempLabel->Appearance.VerticalAlign = ui::Appearance::AlignMiddle;
 	scrollPanel->AddChild(tempLabel);
 
 	class AmbientHeatSimulationAction: public ui::CheckboxAction
@@ -63,13 +86,16 @@ OptionsView::OptionsView():
 		}
 	};
 
-    currentY+=16;
-	ambientHeatSimulation = new ui::Checkbox(ui::Point(8, currentY), ui::Point(Size.X-6, 16), "Ambient heat simulation \bgIntroduced in version 50", "");
+	currentY+=16;
+	ambientHeatSimulation = new ui::Checkbox(ui::Point(8, currentY), ui::Point(1, 16), "Ambient heat simulation \bgIntroduced in version 50", "");
+	autowidth(ambientHeatSimulation);
 	ambientHeatSimulation->SetActionCallback(new AmbientHeatSimulationAction(this));
 	scrollPanel->AddChild(ambientHeatSimulation);
-	currentY+=14;	
-	tempLabel = new ui::Label(ui::Point(24, currentY), ui::Point(Size.X-28, 16), "\bgCan cause odd / broken behaviour with many saves");
-	tempLabel->Appearance.HorizontalAlign = ui::Appearance::AlignLeft;	tempLabel->Appearance.VerticalAlign = ui::Appearance::AlignMiddle;
+	currentY+=14;
+	tempLabel = new ui::Label(ui::Point(24, currentY), ui::Point(1, 16), "\bgCan cause odd / broken behaviour with many saves");
+	autowidth(tempLabel);
+	tempLabel->Appearance.HorizontalAlign = ui::Appearance::AlignLeft;
+	tempLabel->Appearance.VerticalAlign = ui::Appearance::AlignMiddle;
 	scrollPanel->AddChild(tempLabel);
 
 	class NewtonianGravityAction: public ui::CheckboxAction
@@ -82,13 +108,16 @@ OptionsView::OptionsView():
 		}
 	};
 
-    currentY+=16;
-	newtonianGravity = new ui::Checkbox(ui::Point(8, currentY), ui::Point(Size.X-6, 16), "Newtonian gravity \bgIntroduced in version 48", "");
+	currentY+=16;
+	newtonianGravity = new ui::Checkbox(ui::Point(8, currentY), ui::Point(1, 16), "Newtonian gravity \bgIntroduced in version 48", "");
+	autowidth(newtonianGravity);
 	newtonianGravity->SetActionCallback(new NewtonianGravityAction(this));
 	scrollPanel->AddChild(newtonianGravity);
-    currentY+=14;	
-	tempLabel = new ui::Label(ui::Point(24, currentY), ui::Point(Size.X-28, 16), "\bgMay cause poor performance on older computers");
-	tempLabel->Appearance.HorizontalAlign = ui::Appearance::AlignLeft;	tempLabel->Appearance.VerticalAlign = ui::Appearance::AlignMiddle;
+	currentY+=14;
+	tempLabel = new ui::Label(ui::Point(24, currentY), ui::Point(1, 16), "\bgMay cause poor performance on older computers");
+	autowidth(tempLabel);
+	tempLabel->Appearance.HorizontalAlign = ui::Appearance::AlignLeft;
+	tempLabel->Appearance.VerticalAlign = ui::Appearance::AlignMiddle;
 	scrollPanel->AddChild(tempLabel);
 
 	class WaterEqualisationAction: public ui::CheckboxAction
@@ -101,13 +130,16 @@ OptionsView::OptionsView():
 			}
 		};
 
-    currentY+=16;
-	waterEqualisation = new ui::Checkbox(ui::Point(8, currentY), ui::Point(Size.X-6, 16), "Water equalisation \bgIntroduced in version 61", "");
+	currentY+=16;
+	waterEqualisation = new ui::Checkbox(ui::Point(8, currentY), ui::Point(1, 16), "Water equalisation \bgIntroduced in version 61", "");
+	autowidth(waterEqualisation);
 	waterEqualisation->SetActionCallback(new WaterEqualisationAction(this));
 	scrollPanel->AddChild(waterEqualisation);
-    currentY+=14;	
-	tempLabel = new ui::Label(ui::Point(24, currentY), ui::Point(Size.X-28, 16), "\bgMay cause poor performance with a lot of water");
-	tempLabel->Appearance.HorizontalAlign = ui::Appearance::AlignLeft;	tempLabel->Appearance.VerticalAlign = ui::Appearance::AlignMiddle;
+	currentY+=14;
+	tempLabel = new ui::Label(ui::Point(24, currentY), ui::Point(1, 16), "\bgMay cause poor performance with a lot of water");
+	autowidth(tempLabel);
+	tempLabel->Appearance.HorizontalAlign = ui::Appearance::AlignLeft;
+	tempLabel->Appearance.VerticalAlign = ui::Appearance::AlignMiddle;
 	scrollPanel->AddChild(tempLabel);
 
 	class AirModeChanged: public ui::DropDownAction
@@ -119,7 +151,7 @@ OptionsView::OptionsView():
 			v->c->SetAirMode(option.second);
 		}
 	};
-    currentY+=19;
+	currentY+=19;
 	airMode = new ui::DropDown(ui::Point(Size.X-95, currentY), ui::Point(80, 16));
 	scrollPanel->AddChild(airMode);
 	airMode->AddOption(std::pair<String, int>("On", 0));
@@ -130,7 +162,8 @@ OptionsView::OptionsView():
 	airMode->SetActionCallback(new AirModeChanged(this));
 
 	tempLabel = new ui::Label(ui::Point(8, currentY), ui::Point(Size.X-96, 16), "Air Simulation Mode");
-	tempLabel->Appearance.HorizontalAlign = ui::Appearance::AlignLeft;	tempLabel->Appearance.VerticalAlign = ui::Appearance::AlignMiddle;
+	tempLabel->Appearance.HorizontalAlign = ui::Appearance::AlignLeft;
+	tempLabel->Appearance.VerticalAlign = ui::Appearance::AlignMiddle;
 	scrollPanel->AddChild(tempLabel);
 
 	class GravityModeChanged: public ui::DropDownAction
@@ -143,7 +176,7 @@ OptionsView::OptionsView():
 		}
 	};
 
-    currentY+=20;
+	currentY+=20;
 	gravityMode = new ui::DropDown(ui::Point(Size.X-95, currentY), ui::Point(80, 16));
 	scrollPanel->AddChild(gravityMode);
 	gravityMode->AddOption(std::pair<String, int>("Vertical", 0));
@@ -152,7 +185,8 @@ OptionsView::OptionsView():
 	gravityMode->SetActionCallback(new GravityModeChanged(this));
 
 	tempLabel = new ui::Label(ui::Point(8, currentY), ui::Point(Size.X-96, 16), "Gravity Simulation Mode");
-	tempLabel->Appearance.HorizontalAlign = ui::Appearance::AlignLeft;	tempLabel->Appearance.VerticalAlign = ui::Appearance::AlignMiddle;
+	tempLabel->Appearance.HorizontalAlign = ui::Appearance::AlignLeft;
+	tempLabel->Appearance.VerticalAlign = ui::Appearance::AlignMiddle;
 	scrollPanel->AddChild(tempLabel);
 
 	class EdgeModeChanged: public ui::DropDownAction
@@ -164,7 +198,7 @@ OptionsView::OptionsView():
 			v->c->SetEdgeMode(option.second);
 		}
 	};
-    currentY+=20;
+	currentY+=20;
 	edgeMode = new ui::DropDown(ui::Point(Size.X-95, currentY), ui::Point(80, 16));
 	scrollPanel->AddChild(edgeMode);
 	edgeMode->AddOption(std::pair<String, int>("Void", 0));
@@ -173,23 +207,12 @@ OptionsView::OptionsView():
 	edgeMode->SetActionCallback(new EdgeModeChanged(this));
 
 	tempLabel = new ui::Label(ui::Point(8, currentY), ui::Point(Size.X-96, 16), "Edge Mode");
-	tempLabel->Appearance.HorizontalAlign = ui::Appearance::AlignLeft;	tempLabel->Appearance.VerticalAlign = ui::Appearance::AlignMiddle;
+	tempLabel->Appearance.HorizontalAlign = ui::Appearance::AlignLeft;
+	tempLabel->Appearance.VerticalAlign = ui::Appearance::AlignMiddle;
 	scrollPanel->AddChild(tempLabel);
 
-	class Separator : public ui::Component
-	{
-		public:
-		Separator(ui::Point position, ui::Point size) : Component(position, size){}
-		virtual ~Separator(){}
-
-		void Draw(const ui::Point& screenPos)
-		{
-			GetGraphics()->drawrect(screenPos.X, screenPos.Y, Size.X, Size.Y, 255, 255, 255, 180);
-		}		
-	};
-
-    currentY+=20;
-	Separator *tmpSeparator = new Separator(ui::Point(0, currentY), ui::Point(Size.X, 1));
+	currentY+=20;
+	tmpSeparator = new Separator(ui::Point(0, currentY), ui::Point(Size.X, 1));
 	scrollPanel->AddChild(tmpSeparator);
 
 	class ScaleAction: public ui::DropDownAction
@@ -201,7 +224,7 @@ OptionsView::OptionsView():
 			v->c->SetScale(option.second);
 		}
 	};
-    currentY+=4;
+	currentY+=4;
 	scale = new ui::DropDown(ui::Point(8, currentY), ui::Point(40, 16));
 	{
 		int current_scale = ui::Engine::Ref().GetScale();
@@ -221,8 +244,9 @@ OptionsView::OptionsView():
 	scale->SetActionCallback(new ScaleAction(this));
 	scrollPanel->AddChild(scale);
 
-	tempLabel = new ui::Label(ui::Point(scale->Position.X+scale->Size.X+3, currentY), ui::Point(Size.X-28, 16), "\bg- Window scale factor for larger screens");
-	tempLabel->Appearance.HorizontalAlign = ui::Appearance::AlignLeft;	tempLabel->Appearance.VerticalAlign = ui::Appearance::AlignMiddle;
+	tempLabel = new ui::Label(ui::Point(scale->Position.X+scale->Size.X+3, currentY), ui::Point(Size.X-40, 16), "\bg- Window scale factor for larger screens");
+	tempLabel->Appearance.HorizontalAlign = ui::Appearance::AlignLeft;
+	tempLabel->Appearance.VerticalAlign = ui::Appearance::AlignMiddle;
 	scrollPanel->AddChild(tempLabel);
 
 
@@ -236,11 +260,14 @@ OptionsView::OptionsView():
 			v->c->SetResizable(sender->GetChecked());
 		}
 	};
-    currentY+=20;
-	resizable = new ui::Checkbox(ui::Point(8, currentY), ui::Point(Size.X-6, 16), "Resizable", "");
+	currentY+=20;
+	resizable = new ui::Checkbox(ui::Point(8, currentY), ui::Point(1, 16), "Resizable", "");
+	autowidth(resizable);
 	resizable->SetActionCallback(new ResizableAction(this));
-	tempLabel = new ui::Label(ui::Point(resizable->Position.X+Graphics::textwidth(resizable->GetText().c_str())+20, currentY), ui::Point(Size.X-28, 16), "\bg- Allow resizing and maximizing window");
-	tempLabel->Appearance.HorizontalAlign = ui::Appearance::AlignLeft;	tempLabel->Appearance.VerticalAlign = ui::Appearance::AlignMiddle;
+	tempLabel = new ui::Label(ui::Point(resizable->Position.X+Graphics::textwidth(resizable->GetText())+20, currentY), ui::Point(1, 16), "\bg- Allow resizing and maximizing window");
+	autowidth(tempLabel);
+	tempLabel->Appearance.HorizontalAlign = ui::Appearance::AlignLeft;
+	tempLabel->Appearance.VerticalAlign = ui::Appearance::AlignMiddle;
 	scrollPanel->AddChild(tempLabel);
 	scrollPanel->AddChild(resizable);
 
@@ -255,11 +282,14 @@ OptionsView::OptionsView():
 		}
 	};
 
-    currentY+=20;
-	fullscreen = new ui::Checkbox(ui::Point(8, currentY), ui::Point(Size.X-6, 16), "Fullscreen", "");
+	currentY+=20;
+	fullscreen = new ui::Checkbox(ui::Point(8, currentY), ui::Point(1, 16), "Fullscreen", "");
+	autowidth(fullscreen);
 	fullscreen->SetActionCallback(new FullscreenAction(this));
-	tempLabel = new ui::Label(ui::Point(fullscreen->Position.X+Graphics::textwidth(fullscreen->GetText().c_str())+20, currentY), ui::Point(Size.X-28, 16), "\bg- Fill the entire screen");
-	tempLabel->Appearance.HorizontalAlign = ui::Appearance::AlignLeft;	tempLabel->Appearance.VerticalAlign = ui::Appearance::AlignMiddle;
+	tempLabel = new ui::Label(ui::Point(fullscreen->Position.X+Graphics::textwidth(fullscreen->GetText())+20, currentY), ui::Point(1, 16), "\bg- Fill the entire screen");
+	autowidth(tempLabel);
+	tempLabel->Appearance.HorizontalAlign = ui::Appearance::AlignLeft;
+	tempLabel->Appearance.VerticalAlign = ui::Appearance::AlignMiddle;
 	scrollPanel->AddChild(tempLabel);
 	scrollPanel->AddChild(fullscreen);
 
@@ -273,11 +303,14 @@ OptionsView::OptionsView():
 			v->c->SetAltFullscreen(sender->GetChecked());
 		}
 	};
-    currentY+=20;
-	altFullscreen = new ui::Checkbox(ui::Point(23, currentY), ui::Point(Size.X-6, 16), "Change Resolution", "");
+	currentY+=20;
+	altFullscreen = new ui::Checkbox(ui::Point(23, currentY), ui::Point(1, 16), "Change Resolution", "");
+	autowidth(altFullscreen);
 	altFullscreen->SetActionCallback(new AltFullscreenAction(this));
-	tempLabel = new ui::Label(ui::Point(altFullscreen->Position.X+Graphics::textwidth(altFullscreen->GetText().c_str())+20, currentY), ui::Point(Size.X-28, 16), "\bg- Set optimial screen resolution");
-	tempLabel->Appearance.HorizontalAlign = ui::Appearance::AlignLeft;	tempLabel->Appearance.VerticalAlign = ui::Appearance::AlignMiddle;
+	tempLabel = new ui::Label(ui::Point(altFullscreen->Position.X+Graphics::textwidth(altFullscreen->GetText())+20, currentY), ui::Point(1, 16), "\bg- Set optimial screen resolution");
+	autowidth(tempLabel);
+	tempLabel->Appearance.HorizontalAlign = ui::Appearance::AlignLeft;
+	tempLabel->Appearance.VerticalAlign = ui::Appearance::AlignMiddle;
 	scrollPanel->AddChild(tempLabel);
 	scrollPanel->AddChild(altFullscreen);
 
@@ -292,11 +325,14 @@ OptionsView::OptionsView():
 		}
 	};
 
-    currentY+=20;
-	forceIntegerScaling = new ui::Checkbox(ui::Point(23, currentY), ui::Point(Size.X-6, 16), "Force Integer Scaling", "");
+	currentY+=20;
+	forceIntegerScaling = new ui::Checkbox(ui::Point(23, currentY), ui::Point(1, 16), "Force Integer Scaling", "");
+	autowidth(forceIntegerScaling);
 	forceIntegerScaling->SetActionCallback(new ForceIntegerScalingAction(this));
-	tempLabel = new ui::Label(ui::Point(altFullscreen->Position.X+Graphics::textwidth(forceIntegerScaling->GetText().c_str())+20, currentY), ui::Point(Size.X-28, 16), "\bg- less blurry");
-	tempLabel->Appearance.HorizontalAlign = ui::Appearance::AlignLeft;	tempLabel->Appearance.VerticalAlign = ui::Appearance::AlignMiddle;
+	tempLabel = new ui::Label(ui::Point(altFullscreen->Position.X+Graphics::textwidth(forceIntegerScaling->GetText())+20, currentY), ui::Point(1, 16), "\bg- Less blurry");
+	autowidth(tempLabel);
+	tempLabel->Appearance.HorizontalAlign = ui::Appearance::AlignLeft;
+	tempLabel->Appearance.VerticalAlign = ui::Appearance::AlignMiddle;
 	scrollPanel->AddChild(tempLabel);
 	scrollPanel->AddChild(forceIntegerScaling);
 
@@ -310,11 +346,14 @@ OptionsView::OptionsView():
 			v->c->SetFastQuit(sender->GetChecked());
 		}
 	};
-    currentY+=20;
-	fastquit = new ui::Checkbox(ui::Point(8, currentY), ui::Point(Size.X-6, 16), "Fast Quit", "");
+	currentY+=20;
+	fastquit = new ui::Checkbox(ui::Point(8, currentY), ui::Point(1, 16), "Fast Quit", "");
+	autowidth(fastquit);
 	fastquit->SetActionCallback(new FastQuitAction(this));
-	tempLabel = new ui::Label(ui::Point(fastquit->Position.X+Graphics::textwidth(fastquit->GetText().c_str())+20, currentY), ui::Point(Size.X-28, 16), "\bg- Always exit completely when hitting close");
-	tempLabel->Appearance.HorizontalAlign = ui::Appearance::AlignLeft;	tempLabel->Appearance.VerticalAlign = ui::Appearance::AlignMiddle;
+	tempLabel = new ui::Label(ui::Point(fastquit->Position.X+Graphics::textwidth(fastquit->GetText())+20, currentY), ui::Point(1, 16), "\bg- Always exit completely when hitting close");
+	autowidth(tempLabel);
+	tempLabel->Appearance.HorizontalAlign = ui::Appearance::AlignLeft;
+	tempLabel->Appearance.VerticalAlign = ui::Appearance::AlignMiddle;
 	scrollPanel->AddChild(tempLabel);
 	scrollPanel->AddChild(fastquit);
 
@@ -327,11 +366,14 @@ OptionsView::OptionsView():
 			v->c->SetShowAvatars(sender->GetChecked());
 		}
 	};
-    currentY+=20;
-	showAvatars = new ui::Checkbox(ui::Point(8, currentY), ui::Point(Size.X-6, 16), "Show Avatars", "");
+	currentY+=20;
+	showAvatars = new ui::Checkbox(ui::Point(8, currentY), ui::Point(1, 16), "Show Avatars", "");
+	autowidth(showAvatars);
 	showAvatars->SetActionCallback(new ShowAvatarsAction(this));
-	tempLabel = new ui::Label(ui::Point(showAvatars->Position.X+Graphics::textwidth(showAvatars->GetText().c_str())+20, currentY), ui::Point(Size.X-28, 16), "\bg- Disable if you have a slow connection");
-	tempLabel->Appearance.HorizontalAlign = ui::Appearance::AlignLeft;	tempLabel->Appearance.VerticalAlign = ui::Appearance::AlignMiddle;
+	tempLabel = new ui::Label(ui::Point(showAvatars->Position.X+Graphics::textwidth(showAvatars->GetText())+20, currentY), ui::Point(1, 16), "\bg- Disable if you have a slow connection");
+	autowidth(tempLabel);
+	tempLabel->Appearance.HorizontalAlign = ui::Appearance::AlignLeft;
+	tempLabel->Appearance.VerticalAlign = ui::Appearance::AlignMiddle;
 	scrollPanel->AddChild(tempLabel);
 	scrollPanel->AddChild(showAvatars);
 
@@ -344,11 +386,14 @@ OptionsView::OptionsView():
 			v->c->SetMouseClickrequired(sender->GetChecked());
 		}
 	};
-    currentY+=20;
-	mouseClickRequired = new ui::Checkbox(ui::Point(8, currentY), ui::Point(Size.X-6, 16), "Sticky Categories", "");
+	currentY+=20;
+	mouseClickRequired = new ui::Checkbox(ui::Point(8, currentY), ui::Point(1, 16), "Sticky Categories", "");
+	autowidth(mouseClickRequired);
 	mouseClickRequired->SetActionCallback(new MouseClickRequiredAction(this));
-	tempLabel = new ui::Label(ui::Point(mouseClickRequired->Position.X+Graphics::textwidth(mouseClickRequired->GetText().c_str())+20, currentY), ui::Point(Size.X-28, 16), "\bg- Switch between categories by clicking");
-	tempLabel->Appearance.HorizontalAlign = ui::Appearance::AlignLeft;	tempLabel->Appearance.VerticalAlign = ui::Appearance::AlignMiddle;
+	tempLabel = new ui::Label(ui::Point(mouseClickRequired->Position.X+Graphics::textwidth(mouseClickRequired->GetText())+20, currentY), ui::Point(1, 16), "\bg- Switch between categories by clicking");
+	autowidth(tempLabel);
+	tempLabel->Appearance.HorizontalAlign = ui::Appearance::AlignLeft;
+	tempLabel->Appearance.VerticalAlign = ui::Appearance::AlignMiddle;
 	scrollPanel->AddChild(tempLabel);
 	scrollPanel->AddChild(mouseClickRequired);
 
@@ -373,13 +418,15 @@ OptionsView::OptionsView():
 			delete[] workingDirectory;
 		}
 	};
-    currentY+=20;
+	currentY+=20;
 	ui::Button * dataFolderButton = new ui::Button(ui::Point(8, currentY), ui::Point(90, 16), "Open Data Folder");
 	dataFolderButton->SetActionCallback(new DataFolderAction());
 	scrollPanel->AddChild(dataFolderButton);
 
-	tempLabel = new ui::Label(ui::Point(dataFolderButton->Position.X+dataFolderButton->Size.X+3, currentY), ui::Point(Size.X-28, 16), "\bg- Open the data and preferences folder");
-	tempLabel->Appearance.HorizontalAlign = ui::Appearance::AlignLeft;	tempLabel->Appearance.VerticalAlign = ui::Appearance::AlignMiddle;
+	tempLabel = new ui::Label(ui::Point(dataFolderButton->Position.X+dataFolderButton->Size.X+3, currentY), ui::Point(1, 16), "\bg- Open the data and preferences folder");
+	autowidth(tempLabel);
+	tempLabel->Appearance.HorizontalAlign = ui::Appearance::AlignLeft;
+	tempLabel->Appearance.VerticalAlign = ui::Appearance::AlignMiddle;
 	scrollPanel->AddChild(tempLabel);
 
 	class CloseAction: public ui::ButtonAction
@@ -398,7 +445,7 @@ OptionsView::OptionsView():
 	AddComponent(tempButton);
 	SetCancelButton(tempButton);
 	SetOkayButton(tempButton);
-    currentY+=20;
+	currentY+=20;
 	scrollPanel->InnerSize = ui::Point(Size.X, currentY);
 }
 

--- a/src/gui/options/OptionsView.cpp
+++ b/src/gui/options/OptionsView.cpp
@@ -168,6 +168,21 @@ OptionsView::OptionsView():
 	tempLabel->Appearance.HorizontalAlign = ui::Appearance::AlignLeft;	tempLabel->Appearance.VerticalAlign = ui::Appearance::AlignMiddle;
 	scrollPanel->AddChild(tempLabel);
 
+	class HorizontalSeparator : public ui::Component
+	{
+		public:
+		HorizontalSeparator(ui::Point position, ui::Point size) : Component(position, size){}
+		virtual ~HorizontalSeparator(){}
+
+		void Draw(const ui::Point& screenPos)
+		{
+			GetGraphics()->drawrect(screenPos.X, screenPos.Y, Size.X, Size.Y, 255, 255, 255, 180);
+		}		
+	};
+
+	HorizontalSeparator *tmpSeparator = new HorizontalSeparator(ui::Point(10, 183), ui::Point(Size.X-10, 1));
+	scrollPanel->AddChild(tmpSeparator);
+
 	class ScaleAction: public ui::DropDownAction
 	{
 		OptionsView * v;
@@ -403,7 +418,6 @@ void OptionsView::OnDraw()
 	Graphics * g = GetGraphics();
 	g->clearrect(Position.X-2, Position.Y-2, Size.X+3, Size.Y+3);
 	g->drawrect(Position.X, Position.Y, Size.X, Size.Y, 255, 255, 255, 255);
-	g->draw_line(Position.X+1, Position.Y+scale->Position.Y-4, Position.X+Size.X-1, Position.Y+scale->Position.Y-4, 255, 255, 255, 180);
 }
 
 void OptionsView::OnTryExit(ExitMethod method)

--- a/src/gui/options/OptionsView.cpp
+++ b/src/gui/options/OptionsView.cpp
@@ -18,23 +18,22 @@
 #include "gui/interface/DropDown.h"
 #include "gui/interface/Engine.h"
 #include "gui/interface/Checkbox.h"
-#include "gui/interface/DropDown.h"
 
 #include "graphics/Graphics.h"
 
 OptionsView::OptionsView():
-	ui::Window(ui::Point(-1, -1), ui::Point(350, 389)){
-
-	int currentY = 400;
-	scrollPanel = new ui::ScrollPanel(ui::Point(-1, -1), ui::Point(Size.X, Size.Y-16));
+	ui::Window(ui::Point(-1, -1), ui::Point(320, 389)){
 	
-	AddComponent(scrollPanel);
-
 	ui::Label * tempLabel = new ui::Label(ui::Point(4, 5), ui::Point(Size.X-8, 14), "Simulation Options");
 	tempLabel->SetTextColour(style::Colour::InformationTitle);
 	tempLabel->Appearance.HorizontalAlign = ui::Appearance::AlignLeft;	tempLabel->Appearance.VerticalAlign = ui::Appearance::AlignMiddle;
-	scrollPanel->AddChild(tempLabel);
+	AddComponent(tempLabel);
 	
+
+	int currentY = 10;
+	scrollPanel = new ui::ScrollPanel(ui::Point(1, 17), ui::Point(Size.X-2, Size.Y-33));
+	
+	AddComponent(scrollPanel);
 
 	class HeatSimulationAction: public ui::CheckboxAction
 	{
@@ -46,10 +45,11 @@ OptionsView::OptionsView():
 		}
 	};
 
-	heatSimulation = new ui::Checkbox(ui::Point(8, 23), ui::Point(Size.X-6, 16), "Heat simulation \bgIntroduced in version 34", "");
+	heatSimulation = new ui::Checkbox(ui::Point(8, currentY), ui::Point(Size.X-6, 16), "Heat simulation \bgIntroduced in version 34", "");
 	heatSimulation->SetActionCallback(new HeatSimulationAction(this));
 	scrollPanel->AddChild(heatSimulation);
-	tempLabel = new ui::Label(ui::Point(24, heatSimulation->Position.Y+14), ui::Point(Size.X-28, 16), "\bgCan cause odd behaviour when disabled");
+	currentY+=14;
+	tempLabel = new ui::Label(ui::Point(24, currentY), ui::Point(Size.X-28, 16), "\bgCan cause odd behaviour when disabled");
 	tempLabel->Appearance.HorizontalAlign = ui::Appearance::AlignLeft;	tempLabel->Appearance.VerticalAlign = ui::Appearance::AlignMiddle;
 	scrollPanel->AddChild(tempLabel);
 
@@ -63,10 +63,12 @@ OptionsView::OptionsView():
 		}
 	};
 
-	ambientHeatSimulation = new ui::Checkbox(ui::Point(8, 53), ui::Point(Size.X-6, 16), "Ambient heat simulation \bgIntroduced in version 50", "");
+    currentY+=16;
+	ambientHeatSimulation = new ui::Checkbox(ui::Point(8, currentY), ui::Point(Size.X-6, 16), "Ambient heat simulation \bgIntroduced in version 50", "");
 	ambientHeatSimulation->SetActionCallback(new AmbientHeatSimulationAction(this));
 	scrollPanel->AddChild(ambientHeatSimulation);
-	tempLabel = new ui::Label(ui::Point(24, ambientHeatSimulation->Position.Y+14), ui::Point(Size.X-28, 16), "\bgCan cause odd / broken behaviour with many saves");
+	currentY+=14;	
+	tempLabel = new ui::Label(ui::Point(24, currentY), ui::Point(Size.X-28, 16), "\bgCan cause odd / broken behaviour with many saves");
 	tempLabel->Appearance.HorizontalAlign = ui::Appearance::AlignLeft;	tempLabel->Appearance.VerticalAlign = ui::Appearance::AlignMiddle;
 	scrollPanel->AddChild(tempLabel);
 
@@ -80,10 +82,12 @@ OptionsView::OptionsView():
 		}
 	};
 
-	newtonianGravity = new ui::Checkbox(ui::Point(8, 83), ui::Point(Size.X-6, 16), "Newtonian gravity \bgIntroduced in version 48", "");
+    currentY+=16;
+	newtonianGravity = new ui::Checkbox(ui::Point(8, currentY), ui::Point(Size.X-6, 16), "Newtonian gravity \bgIntroduced in version 48", "");
 	newtonianGravity->SetActionCallback(new NewtonianGravityAction(this));
 	scrollPanel->AddChild(newtonianGravity);
-	tempLabel = new ui::Label(ui::Point(24, newtonianGravity->Position.Y+14), ui::Point(Size.X-28, 16), "\bgMay cause poor performance on older computers");
+    currentY+=14;	
+	tempLabel = new ui::Label(ui::Point(24, currentY), ui::Point(Size.X-28, 16), "\bgMay cause poor performance on older computers");
 	tempLabel->Appearance.HorizontalAlign = ui::Appearance::AlignLeft;	tempLabel->Appearance.VerticalAlign = ui::Appearance::AlignMiddle;
 	scrollPanel->AddChild(tempLabel);
 
@@ -97,10 +101,12 @@ OptionsView::OptionsView():
 			}
 		};
 
-	waterEqualisation = new ui::Checkbox(ui::Point(8, 113), ui::Point(Size.X-6, 16), "Water equalisation \bgIntroduced in version 61", "");
+    currentY+=16;
+	waterEqualisation = new ui::Checkbox(ui::Point(8, currentY), ui::Point(Size.X-6, 16), "Water equalisation \bgIntroduced in version 61", "");
 	waterEqualisation->SetActionCallback(new WaterEqualisationAction(this));
 	scrollPanel->AddChild(waterEqualisation);
-	tempLabel = new ui::Label(ui::Point(24, waterEqualisation->Position.Y+14), ui::Point(Size.X-28, 16), "\bgMay cause poor performance with a lot of water");
+    currentY+=14;	
+	tempLabel = new ui::Label(ui::Point(24, currentY), ui::Point(Size.X-28, 16), "\bgMay cause poor performance with a lot of water");
 	tempLabel->Appearance.HorizontalAlign = ui::Appearance::AlignLeft;	tempLabel->Appearance.VerticalAlign = ui::Appearance::AlignMiddle;
 	scrollPanel->AddChild(tempLabel);
 
@@ -113,7 +119,8 @@ OptionsView::OptionsView():
 			v->c->SetAirMode(option.second);
 		}
 	};
-	airMode = new ui::DropDown(ui::Point(Size.X-88, 146), ui::Point(80, 16));
+    currentY+=19;
+	airMode = new ui::DropDown(ui::Point(Size.X-95, currentY), ui::Point(80, 16));
 	scrollPanel->AddChild(airMode);
 	airMode->AddOption(std::pair<String, int>("On", 0));
 	airMode->AddOption(std::pair<String, int>("Pressure off", 1));
@@ -122,7 +129,7 @@ OptionsView::OptionsView():
 	airMode->AddOption(std::pair<String, int>("No Update", 4));
 	airMode->SetActionCallback(new AirModeChanged(this));
 
-	tempLabel = new ui::Label(ui::Point(8, 146), ui::Point(Size.X-96, 16), "Air Simulation Mode");
+	tempLabel = new ui::Label(ui::Point(8, currentY), ui::Point(Size.X-96, 16), "Air Simulation Mode");
 	tempLabel->Appearance.HorizontalAlign = ui::Appearance::AlignLeft;	tempLabel->Appearance.VerticalAlign = ui::Appearance::AlignMiddle;
 	scrollPanel->AddChild(tempLabel);
 
@@ -136,14 +143,15 @@ OptionsView::OptionsView():
 		}
 	};
 
-	gravityMode = new ui::DropDown(ui::Point(Size.X-88, 166), ui::Point(80, 16));
+    currentY+=20;
+	gravityMode = new ui::DropDown(ui::Point(Size.X-95, currentY), ui::Point(80, 16));
 	scrollPanel->AddChild(gravityMode);
 	gravityMode->AddOption(std::pair<String, int>("Vertical", 0));
 	gravityMode->AddOption(std::pair<String, int>("Off", 1));
 	gravityMode->AddOption(std::pair<String, int>("Radial", 2));
 	gravityMode->SetActionCallback(new GravityModeChanged(this));
 
-	tempLabel = new ui::Label(ui::Point(8, 166), ui::Point(Size.X-96, 16), "Gravity Simulation Mode");
+	tempLabel = new ui::Label(ui::Point(8, currentY), ui::Point(Size.X-96, 16), "Gravity Simulation Mode");
 	tempLabel->Appearance.HorizontalAlign = ui::Appearance::AlignLeft;	tempLabel->Appearance.VerticalAlign = ui::Appearance::AlignMiddle;
 	scrollPanel->AddChild(tempLabel);
 
@@ -156,23 +164,23 @@ OptionsView::OptionsView():
 			v->c->SetEdgeMode(option.second);
 		}
 	};
-
-	edgeMode = new ui::DropDown(ui::Point(Size.X-88, 186), ui::Point(80, 16));
+    currentY+=20;
+	edgeMode = new ui::DropDown(ui::Point(Size.X-95, currentY), ui::Point(80, 16));
 	scrollPanel->AddChild(edgeMode);
 	edgeMode->AddOption(std::pair<String, int>("Void", 0));
 	edgeMode->AddOption(std::pair<String, int>("Solid", 1));
 	edgeMode->AddOption(std::pair<String, int>("Loop", 2));
 	edgeMode->SetActionCallback(new EdgeModeChanged(this));
 
-	tempLabel = new ui::Label(ui::Point(8, 186), ui::Point(Size.X-96, 16), "Edge Mode");
+	tempLabel = new ui::Label(ui::Point(8, currentY), ui::Point(Size.X-96, 16), "Edge Mode");
 	tempLabel->Appearance.HorizontalAlign = ui::Appearance::AlignLeft;	tempLabel->Appearance.VerticalAlign = ui::Appearance::AlignMiddle;
 	scrollPanel->AddChild(tempLabel);
 
-	class HorizontalSeparator : public ui::Component
+	class Separator : public ui::Component
 	{
 		public:
-		HorizontalSeparator(ui::Point position, ui::Point size) : Component(position, size){}
-		virtual ~HorizontalSeparator(){}
+		Separator(ui::Point position, ui::Point size) : Component(position, size){}
+		virtual ~Separator(){}
 
 		void Draw(const ui::Point& screenPos)
 		{
@@ -180,7 +188,8 @@ OptionsView::OptionsView():
 		}		
 	};
 
-	HorizontalSeparator *tmpSeparator = new HorizontalSeparator(ui::Point(10, 183), ui::Point(Size.X-10, 1));
+    currentY+=20;
+	Separator *tmpSeparator = new Separator(ui::Point(0, currentY), ui::Point(Size.X, 1));
 	scrollPanel->AddChild(tmpSeparator);
 
 	class ScaleAction: public ui::DropDownAction
@@ -192,7 +201,8 @@ OptionsView::OptionsView():
 			v->c->SetScale(option.second);
 		}
 	};
-	scale = new ui::DropDown(ui::Point(8, 210), ui::Point(40, 16));
+    currentY+=4;
+	scale = new ui::DropDown(ui::Point(8, currentY), ui::Point(40, 16));
 	{
 		int current_scale = ui::Engine::Ref().GetScale();
 		int ix_scale = 1;
@@ -211,7 +221,7 @@ OptionsView::OptionsView():
 	scale->SetActionCallback(new ScaleAction(this));
 	scrollPanel->AddChild(scale);
 
-	tempLabel = new ui::Label(ui::Point(scale->Position.X+scale->Size.X+3, scale->Position.Y), ui::Point(Size.X-28, 16), "\bg- Window scale factor for larger screens");
+	tempLabel = new ui::Label(ui::Point(scale->Position.X+scale->Size.X+3, currentY), ui::Point(Size.X-28, 16), "\bg- Window scale factor for larger screens");
 	tempLabel->Appearance.HorizontalAlign = ui::Appearance::AlignLeft;	tempLabel->Appearance.VerticalAlign = ui::Appearance::AlignMiddle;
 	scrollPanel->AddChild(tempLabel);
 
@@ -226,10 +236,10 @@ OptionsView::OptionsView():
 			v->c->SetResizable(sender->GetChecked());
 		}
 	};
-
-	resizable = new ui::Checkbox(ui::Point(8, scale->Position.Y + 20), ui::Point(Size.X-6, 16), "Resizable", "");
+    currentY+=20;
+	resizable = new ui::Checkbox(ui::Point(8, currentY), ui::Point(Size.X-6, 16), "Resizable", "");
 	resizable->SetActionCallback(new ResizableAction(this));
-	tempLabel = new ui::Label(ui::Point(resizable->Position.X+Graphics::textwidth(resizable->GetText().c_str())+20, resizable->Position.Y), ui::Point(Size.X-28, 16), "\bg- Allow resizing and maximizing window");
+	tempLabel = new ui::Label(ui::Point(resizable->Position.X+Graphics::textwidth(resizable->GetText().c_str())+20, currentY), ui::Point(Size.X-28, 16), "\bg- Allow resizing and maximizing window");
 	tempLabel->Appearance.HorizontalAlign = ui::Appearance::AlignLeft;	tempLabel->Appearance.VerticalAlign = ui::Appearance::AlignMiddle;
 	scrollPanel->AddChild(tempLabel);
 	scrollPanel->AddChild(resizable);
@@ -245,9 +255,10 @@ OptionsView::OptionsView():
 		}
 	};
 
-	fullscreen = new ui::Checkbox(ui::Point(8, resizable->Position.Y + 20), ui::Point(Size.X-6, 16), "Fullscreen", "");
+    currentY+=20;
+	fullscreen = new ui::Checkbox(ui::Point(8, currentY), ui::Point(Size.X-6, 16), "Fullscreen", "");
 	fullscreen->SetActionCallback(new FullscreenAction(this));
-	tempLabel = new ui::Label(ui::Point(fullscreen->Position.X+Graphics::textwidth(fullscreen->GetText().c_str())+20, fullscreen->Position.Y), ui::Point(Size.X-28, 16), "\bg- Fill the entire screen");
+	tempLabel = new ui::Label(ui::Point(fullscreen->Position.X+Graphics::textwidth(fullscreen->GetText().c_str())+20, currentY), ui::Point(Size.X-28, 16), "\bg- Fill the entire screen");
 	tempLabel->Appearance.HorizontalAlign = ui::Appearance::AlignLeft;	tempLabel->Appearance.VerticalAlign = ui::Appearance::AlignMiddle;
 	scrollPanel->AddChild(tempLabel);
 	scrollPanel->AddChild(fullscreen);
@@ -262,10 +273,10 @@ OptionsView::OptionsView():
 			v->c->SetAltFullscreen(sender->GetChecked());
 		}
 	};
-
-	altFullscreen = new ui::Checkbox(ui::Point(23, fullscreen->Position.Y + 20), ui::Point(Size.X-6, 16), "Change Resolution", "");
+    currentY+=20;
+	altFullscreen = new ui::Checkbox(ui::Point(23, currentY), ui::Point(Size.X-6, 16), "Change Resolution", "");
 	altFullscreen->SetActionCallback(new AltFullscreenAction(this));
-	tempLabel = new ui::Label(ui::Point(altFullscreen->Position.X+Graphics::textwidth(altFullscreen->GetText().c_str())+20, altFullscreen->Position.Y), ui::Point(Size.X-28, 16), "\bg- Set optimial screen resolution");
+	tempLabel = new ui::Label(ui::Point(altFullscreen->Position.X+Graphics::textwidth(altFullscreen->GetText().c_str())+20, currentY), ui::Point(Size.X-28, 16), "\bg- Set optimial screen resolution");
 	tempLabel->Appearance.HorizontalAlign = ui::Appearance::AlignLeft;	tempLabel->Appearance.VerticalAlign = ui::Appearance::AlignMiddle;
 	scrollPanel->AddChild(tempLabel);
 	scrollPanel->AddChild(altFullscreen);
@@ -281,9 +292,10 @@ OptionsView::OptionsView():
 		}
 	};
 
-	forceIntegerScaling = new ui::Checkbox(ui::Point(23, altFullscreen->Position.Y + 20), ui::Point(Size.X-6, 16), "Force Integer Scaling", "");
+    currentY+=20;
+	forceIntegerScaling = new ui::Checkbox(ui::Point(23, currentY), ui::Point(Size.X-6, 16), "Force Integer Scaling", "");
 	forceIntegerScaling->SetActionCallback(new ForceIntegerScalingAction(this));
-	tempLabel = new ui::Label(ui::Point(altFullscreen->Position.X+Graphics::textwidth(forceIntegerScaling->GetText().c_str())+20, forceIntegerScaling->Position.Y), ui::Point(Size.X-28, 16), "\bg- less blurry");
+	tempLabel = new ui::Label(ui::Point(altFullscreen->Position.X+Graphics::textwidth(forceIntegerScaling->GetText().c_str())+20, currentY), ui::Point(Size.X-28, 16), "\bg- less blurry");
 	tempLabel->Appearance.HorizontalAlign = ui::Appearance::AlignLeft;	tempLabel->Appearance.VerticalAlign = ui::Appearance::AlignMiddle;
 	scrollPanel->AddChild(tempLabel);
 	scrollPanel->AddChild(forceIntegerScaling);
@@ -298,10 +310,10 @@ OptionsView::OptionsView():
 			v->c->SetFastQuit(sender->GetChecked());
 		}
 	};
-
-	fastquit = new ui::Checkbox(ui::Point(8, forceIntegerScaling->Position.Y + 20), ui::Point(Size.X-6, 16), "Fast Quit", "");
+    currentY+=20;
+	fastquit = new ui::Checkbox(ui::Point(8, currentY), ui::Point(Size.X-6, 16), "Fast Quit", "");
 	fastquit->SetActionCallback(new FastQuitAction(this));
-	tempLabel = new ui::Label(ui::Point(fastquit->Position.X+Graphics::textwidth(fastquit->GetText().c_str())+20, fastquit->Position.Y), ui::Point(Size.X-28, 16), "\bg- Always exit completely when hitting close");
+	tempLabel = new ui::Label(ui::Point(fastquit->Position.X+Graphics::textwidth(fastquit->GetText().c_str())+20, currentY), ui::Point(Size.X-28, 16), "\bg- Always exit completely when hitting close");
 	tempLabel->Appearance.HorizontalAlign = ui::Appearance::AlignLeft;	tempLabel->Appearance.VerticalAlign = ui::Appearance::AlignMiddle;
 	scrollPanel->AddChild(tempLabel);
 	scrollPanel->AddChild(fastquit);
@@ -315,10 +327,10 @@ OptionsView::OptionsView():
 			v->c->SetShowAvatars(sender->GetChecked());
 		}
 	};
-
-	showAvatars = new ui::Checkbox(ui::Point(8, fastquit->Position.Y + 20), ui::Point(Size.X-6, 16), "Show Avatars", "");
+    currentY+=20;
+	showAvatars = new ui::Checkbox(ui::Point(8, currentY), ui::Point(Size.X-6, 16), "Show Avatars", "");
 	showAvatars->SetActionCallback(new ShowAvatarsAction(this));
-	tempLabel = new ui::Label(ui::Point(showAvatars->Position.X+Graphics::textwidth(showAvatars->GetText().c_str())+20, showAvatars->Position.Y), ui::Point(Size.X-28, 16), "\bg- Disable if you have a slow connection");
+	tempLabel = new ui::Label(ui::Point(showAvatars->Position.X+Graphics::textwidth(showAvatars->GetText().c_str())+20, currentY), ui::Point(Size.X-28, 16), "\bg- Disable if you have a slow connection");
 	tempLabel->Appearance.HorizontalAlign = ui::Appearance::AlignLeft;	tempLabel->Appearance.VerticalAlign = ui::Appearance::AlignMiddle;
 	scrollPanel->AddChild(tempLabel);
 	scrollPanel->AddChild(showAvatars);
@@ -332,10 +344,10 @@ OptionsView::OptionsView():
 			v->c->SetMouseClickrequired(sender->GetChecked());
 		}
 	};
-
-	mouseClickRequired = new ui::Checkbox(ui::Point(8, showAvatars->Position.Y + 20), ui::Point(Size.X-6, 16), "Mouse click required", "");
+    currentY+=20;
+	mouseClickRequired = new ui::Checkbox(ui::Point(8, currentY), ui::Point(Size.X-6, 16), "Sticky Categories", "");
 	mouseClickRequired->SetActionCallback(new MouseClickRequiredAction(this));
-	tempLabel = new ui::Label(ui::Point(mouseClickRequired->Position.X+Graphics::textwidth(mouseClickRequired->GetText().c_str())+20, mouseClickRequired->Position.Y), ui::Point(Size.X-28, 16), "\bg- click required to change category in menu");
+	tempLabel = new ui::Label(ui::Point(mouseClickRequired->Position.X+Graphics::textwidth(mouseClickRequired->GetText().c_str())+20, currentY), ui::Point(Size.X-28, 16), "\bg- Switch between categories by clicking");
 	tempLabel->Appearance.HorizontalAlign = ui::Appearance::AlignLeft;	tempLabel->Appearance.VerticalAlign = ui::Appearance::AlignMiddle;
 	scrollPanel->AddChild(tempLabel);
 	scrollPanel->AddChild(mouseClickRequired);
@@ -361,11 +373,12 @@ OptionsView::OptionsView():
 			delete[] workingDirectory;
 		}
 	};
-	ui::Button * dataFolderButton = new ui::Button(ui::Point(8, mouseClickRequired->Position.Y + 20), ui::Point(90, 16), "Open Data Folder");
+    currentY+=20;
+	ui::Button * dataFolderButton = new ui::Button(ui::Point(8, currentY), ui::Point(90, 16), "Open Data Folder");
 	dataFolderButton->SetActionCallback(new DataFolderAction());
 	scrollPanel->AddChild(dataFolderButton);
 
-	tempLabel = new ui::Label(ui::Point(dataFolderButton->Position.X+dataFolderButton->Size.X+3, dataFolderButton->Position.Y), ui::Point(Size.X-28, 16), "\bg- Open the data and preferences folder");
+	tempLabel = new ui::Label(ui::Point(dataFolderButton->Position.X+dataFolderButton->Size.X+3, currentY), ui::Point(Size.X-28, 16), "\bg- Open the data and preferences folder");
 	tempLabel->Appearance.HorizontalAlign = ui::Appearance::AlignLeft;	tempLabel->Appearance.VerticalAlign = ui::Appearance::AlignMiddle;
 	scrollPanel->AddChild(tempLabel);
 
@@ -385,7 +398,7 @@ OptionsView::OptionsView():
 	AddComponent(tempButton);
 	SetCancelButton(tempButton);
 	SetOkayButton(tempButton);
-
+    currentY+=20;
 	scrollPanel->InnerSize = ui::Point(Size.X, currentY);
 }
 

--- a/src/gui/options/OptionsView.h
+++ b/src/gui/options/OptionsView.h
@@ -2,6 +2,7 @@
 #define OPTIONSVIEW_H_
 
 #include "gui/interface/Window.h"
+#include "gui/interface/ScrollPanel.h"
 
 namespace ui
 {
@@ -29,6 +30,8 @@ class OptionsView: public ui::Window
 	ui::Checkbox * forceIntegerScaling;
 	ui::Checkbox * fastquit;
 	ui::Checkbox * showAvatars;
+	ui::Checkbox * mouseClickRequired;
+	ui::ScrollPanel * scrollPanel;
 public:
 	OptionsView();
 	void NotifySettingsChanged(OptionsModel * sender);


### PR DESCRIPTION
New option in the menu and config file is available. This new menu behavior is disabled by default.
Current menu selection is little annoying when selected category accidentally changes during rapid mouse move.
