### PR TITLE
Check SDL2 framework on OSX

### DIFF
--- a/SConscript
+++ b/SConscript
@@ -238,9 +238,9 @@ def findLibs(env, conf):
 
 	#Look for SDL
 	runSdlConfig = platform == "Linux" or compilePlatform == "Linux" or platform == "FreeBSD"
-	#if platform == "Darwin" and conf.CheckFramework("SDL"):
-	#	runSdlConfig = False
-	if not conf.CheckLib("SDL2"):
+	if platform == "Darwin" and conf.CheckFramework("SDL2"):
+		runSdlConfig = False
+	elif not conf.CheckLib("SDL2"):
 		FatalError("SDL2 development library not found or not installed")
 
 	if runSdlConfig:


### PR DESCRIPTION
For Mac OSX builds, the SDL2 framework wasn't getting checked properly and was throwing a fatal error because it was looking for the SDL2 lib rather than the framework. This PR fixes this issue which was halting myself from building on a Mac.