### PR TITLE
Do a single CoordStack allocation per thread

### DIFF
--- a/src/simulation/Simulation.cpp
+++ b/src/simulation/Simulation.cpp
@@ -596,8 +596,9 @@ bool Simulation::FloodFillPmapCheck(int x, int y, int type)
 		return TYP(pmap[y][x]) == type;
 }
 
-CoordStack& Simulation::getCoordStackSingleton ()
+CoordStack& Simulation::getCoordStackSingleton()
 {
+	// Future-proofing in case Simulation is later multithreaded
 	thread_local CoordStack cs;
 	return cs;
 }

--- a/src/simulation/Simulation.cpp
+++ b/src/simulation/Simulation.cpp
@@ -596,7 +596,8 @@ bool Simulation::FloodFillPmapCheck(int x, int y, int type)
 		return TYP(pmap[y][x]) == type;
 }
 
-CoordStack& getCoordStackSingleton () {
+CoordStack& Simulation::getCoordStackSingleton ()
+{
 	thread_local CoordStack cs;
 	return cs;
 }

--- a/src/simulation/Simulation.cpp
+++ b/src/simulation/Simulation.cpp
@@ -618,7 +618,7 @@ int Simulation::flood_prop(int x, int y, size_t propoffset, PropertyValue propva
 	{
 		CoordStack& cs = getCoordStackSingleton();
 		cs.clear();
-		
+
 		cs.push(x, y);
 		do
 		{
@@ -749,7 +749,8 @@ int Simulation::FloodINST(int x, int y, int fullc, int cm)
 	if (TYP(pmap[y][x])!=cm || parts[ID(pmap[y][x])].life!=0)
 		return 1;
 
-	CoordStack cs;
+	CoordStack& cs = getCoordStackSingleton();
+	cs.clear();
 
 	cs.push(x, y);
 
@@ -861,7 +862,9 @@ bool Simulation::flood_water(int x, int y, int i)
 
 	try
 	{
-		CoordStack cs;
+		CoordStack& cs = getCoordStackSingleton();
+		cs.clear();
+
 		cs.push(x, y);
 		do
 		{
@@ -1197,7 +1200,9 @@ void Simulation::ApplyDecorationFill(Renderer *ren, int x, int y, int colR, int 
 
 	try
 	{
-		CoordStack cs;
+		CoordStack& cs = getCoordStackSingleton();
+		cs.clear();
+		
 		cs.push(x, y);
 		do
 		{

--- a/src/simulation/Simulation.cpp
+++ b/src/simulation/Simulation.cpp
@@ -596,6 +596,11 @@ bool Simulation::FloodFillPmapCheck(int x, int y, int type)
 		return TYP(pmap[y][x]) == type;
 }
 
+CoordStack& getCoordStackSingleton () {
+	thread_local CoordStack cs;
+	return cs;
+}
+
 int Simulation::flood_prop(int x, int y, size_t propoffset, PropertyValue propvalue, StructProperty::PropertyType proptype)
 {
 	int i, x1, x2, dy = 1;
@@ -611,7 +616,9 @@ int Simulation::flood_prop(int x, int y, size_t propoffset, PropertyValue propva
 	memset(bitmap, 0, XRES*YRES);
 	try
 	{
-		CoordStack cs;
+		CoordStack& cs = getCoordStackSingleton();
+		cs.clear();
+		
 		cs.push(x, y);
 		do
 		{

--- a/src/simulation/Simulation.h
+++ b/src/simulation/Simulation.h
@@ -13,6 +13,8 @@
 #include "GOLMenu.h"
 #include "MenuSection.h"
 
+#include "CoordStack.h"
+
 #include "elements/Element.h"
 
 #define CHANNELS ((int)(MAX_TEMP-73)/100+2)
@@ -218,6 +220,9 @@ public:
 
 	String ElementResolve(int type, int ctype);
 	String BasicParticleInfo(Particle const &sample_part);
+
+private:
+	CoordStack& getCoordStackSingleton ();
 };
 
 #endif /* SIMULATION_H */

--- a/src/simulation/Simulation.h
+++ b/src/simulation/Simulation.h
@@ -222,7 +222,7 @@ public:
 	String BasicParticleInfo(Particle const &sample_part);
 
 private:
-	CoordStack& getCoordStackSingleton ();
+	CoordStack& getCoordStackSingleton();
 };
 
 #endif /* SIMULATION_H */


### PR DESCRIPTION
I used a thread_local, as suggested https://github.com/The-Powder-Toy/The-Powder-Toy/pull/676#issuecomment-529158041