### PR TITLE
Smooth/organic elliptical brush

### DIFF
--- a/src/gui/game/EllipseBrush.h
+++ b/src/gui/game/EllipseBrush.h
@@ -31,7 +31,9 @@ public:
 			int yTop = ry+1, yBottom, i;
 			for (i = 0; i <= rx; i++)
 			{
-				while (pow(i-rx,2.0)*pow(ry,2.0) + pow(yTop-ry,2.0)*pow(rx,2.0) <= pow(rx,2.0)*pow(ry,2.0))
+				while (	pow(i - rx, 2.0) * pow(ry - 0.5, 2.0) +
+						pow(yTop - ry, 2.0) * pow(rx - 0.5, 2.0) <=
+							pow(rx, 2.0) * pow(ry, 2.0))
 					yTop++;
 				yBottom = 2*ry - yTop;
 				for (int j = 0; j <= ry*2; j++)


### PR DESCRIPTION
Not sure why TPT's elliptical brush currently looks like that - when you type "pixel circle" on Google every result is the smooth version.

Here's a quick image comparison (top is smooth, bottom is current):
![image](https://user-images.githubusercontent.com/6632271/65583819-903d6600-df88-11e9-86a6-13810af73c09.png)z

Wasn't sure how to integrate it - I added it as an brush (second in the list) which is probably not preferable (?). It could be a option for the current brush or it could replace it.

Got the idea from this post: https://powdertoy.co.uk/Browse/View.html?ID=2464991