### PR TITLE
Add the --ignore-updates option to Sconscript

### DIFF
--- a/SConscript
+++ b/SConscript
@@ -46,6 +46,7 @@ AddSconsOption("tool", False, True, "Tool prefix appended before gcc/g++.")
 
 AddSconsOption('beta', False, False, "Beta build.")
 AddSconsOption('no-install-prompt', False, False, "Disable the \"do you want to install Powder Toy?\" prompt.")
+AddSconsOption('ignore-updates', False, False, "Disable checking for updates.")
 AddSconsOption('save-version', False, True, "Save version.")
 AddSconsOption('minor-version', False, True, "Minor version.")
 AddSconsOption('build-number', False, True, "Build number.")
@@ -549,6 +550,8 @@ if GetOption('beta'):
 	env.Append(CPPDEFINES=['BETA'])
 if GetOption('no-install-prompt'):
 	env.Append(CPPDEFINES=['NO_INSTALL_CHECK'])
+if GetOption('ignore-updates'):
+	env.Append(CPPDEFINES=['IGNORE_UPDATES'])
 
 
 #Generate list of sources to compile


### PR DESCRIPTION
This changeset adds the `--no-update-check` option to Sconscript, offering a way to disable to built-in update checker. This can be useful for Linux distributions and other situations where the program is installed system-wide by an administrator, instead of locally per user.