### PR TITLE
Simulation::create_part sanity check

### DIFF
--- a/src/simulation/Simulation.cpp
+++ b/src/simulation/Simulation.cpp
@@ -3112,9 +3112,7 @@ int Simulation::create_part(int p, int x, int y, int t, int v)
 {
 	int i, oldType = PT_NONE;
 
-	if (x<0 || y<0 || x>=XRES || y>=YRES)
-		return -1;
-	if (t>=0 && t<PT_NUM && !elements[t].Enabled)
+	if (x<0 || y<0 || x>=XRES || y>=YRES || t<=0 || t>=PT_NUM || !elements[t].Enabled)
 		return -1;
 
 	if (t == PT_SPRK && !(p == -2 && elements[TYP(pmap[y][x])].CtypeDraw))


### PR DESCRIPTION
Previous check didn't work if t>PT_NUM

Fun fact: passing arbitrary type to Simulation::create_part before this fix could lead to easy arbitrary code execution