### PR TITLE
Cast malloc() in opt_meth_setoption

### DIFF
--- a/src/lua/socket/options.c
+++ b/src/lua/socket/options.c
@@ -32,7 +32,7 @@ int opt_meth_setoption(lua_State *L, p_opt opt, p_socket ps)
     while (opt->name && strcmp(name, opt->name))
         opt++;
     if (!opt->func) {
-        char* msg = malloc(30+strlen(name));
+        char* msg = (char*)malloc(30+strlen(name));
         sprintf(msg, "unsupported option `%.35s'", name);
         luaL_argerror(L, 2, msg);
         free(msg);


### PR DESCRIPTION
may throw errors for certain compilers, as it did for me (afl-gcc)