### PR TITLE
Customize BRAY collision life (https://tpt.io/.311987)

### DIFF
--- a/src/simulation/elements/ARAY.cpp
+++ b/src/simulation/elements/ARAY.cpp
@@ -47,6 +47,7 @@ void Element::Element_ARAY()
 
 static int update(UPDATE_FUNC_ARGS)
 {
+	int long_bray_life = parts[i].life > 0 ? parts[i].life : 1020;
 	for (int rx = -1; rx <= 1; rx++)
 	{
 		for (int ry = -1; ry <= 1; ry++)
@@ -99,7 +100,7 @@ static int update(UPDATE_FUNC_ARGS)
 								case 0:
 									if (nyy != 0 || nxx !=0)
 									{
-										parts[r].life = 1020; // makes it last a while
+										parts[r].life = long_bray_life; // makes it last a while
 										parts[r].tmp = 1;
 										if (!parts[r].ctype) // and colors it if it isn't already
 											parts[r].ctype = colored;
@@ -111,7 +112,7 @@ static int update(UPDATE_FUNC_ARGS)
 									break;
 								// long life, reset it
 								case 1:
-									parts[r].life = 1020;
+									parts[r].life = long_bray_life;
 									//docontinue = 1;
 									break;
 								}


### PR DESCRIPTION
[See https://tpt.io/.311987](https://tpt.io/.311987) - Credit to fusionftw for the idea

Now ARAY with a life > 0, when beams collide, the solid BRAY will have the life of the ARAY instead of a default life of 1020 (If life = 0, unaffected).

The life of the created BRAY is particle order dependent - the 2nd ARAY to fire into the BRAY sets the life (this could be an interesting mechanic). "Solid" BRAY can also have its life changed by another ARAY with a different life firing at it, which resets the life of the solid BRAY to the life of the ARAY.