### PR TITLE
Make CONV conditionally preserve particle fields

### DIFF
--- a/src/simulation/elements/CONV.cpp
+++ b/src/simulation/elements/CONV.cpp
@@ -87,7 +87,10 @@ static int update(UPDATE_FUNC_ARGS)
 						continue;
 					if (TYP(r) != PT_CONV && TYP(r) != PT_DMND && TYP(r) != ctype)
 					{
-						sim->create_part(ID(r), x+rx, y+ry, TYP(parts[i].ctype), ID(parts[i].ctype));
+						if (parts[i].pavg[0]) // if .pavg0 is set, preserve particle fields on conversion
+							sim->part_change_type(ID(r), x+rx, y+ry, TYP(parts[i].ctype));
+						else
+							sim->create_part(ID(r), x+rx, y+ry, TYP(parts[i].ctype), ID(parts[i].ctype));
 					}
 				}
 	}


### PR DESCRIPTION
Now, if pavg0 is set, CONV will not zero out particle fields such as .ctype, .tmp, .tmp2, etc