### PR TITLE
Make Copy and Cut buttons disappear when no text is selected

### DIFF
--- a/src/gui/interface/Textbox.cpp
+++ b/src/gui/interface/Textbox.cpp
@@ -32,8 +32,8 @@ Textbox::Textbox(Point position, Point size, String textboxText, String textboxP
 	cursor = text.length();
 
 	menu->RemoveItem(0);
-	// menu->AddItem(ContextMenuItem("Cut", 1, true));
-	// menu->AddItem(ContextMenuItem("Copy", 0, true));
+	menu->AddItem(ContextMenuItem("Cut", 1, true));
+	menu->AddItem(ContextMenuItem("Copy", 0, true));
 	menu->AddItem(ContextMenuItem("Paste", 2, true));
 }
 

--- a/src/gui/interface/Textbox.cpp
+++ b/src/gui/interface/Textbox.cpp
@@ -32,8 +32,8 @@ Textbox::Textbox(Point position, Point size, String textboxText, String textboxP
 	cursor = text.length();
 
 	menu->RemoveItem(0);
-	menu->AddItem(ContextMenuItem("Cut", 1, true));
-	menu->AddItem(ContextMenuItem("Copy", 0, true));
+	// menu->AddItem(ContextMenuItem("Cut", 1, true));
+	// menu->AddItem(ContextMenuItem("Copy", 0, true));
 	menu->AddItem(ContextMenuItem("Paste", 2, true));
 }
 
@@ -503,7 +503,25 @@ void Textbox::OnTextInput(String text)
 
 void Textbox::OnMouseClick(int x, int y, unsigned button)
 {
-
+	if (button == SDL_BUTTON_RIGHT)
+	{
+		if (HasSelection())
+		{
+			menu->RemoveItem(0);
+			menu->RemoveItem(1);
+			menu->RemoveItem(2);
+			menu->AddItem(ContextMenuItem("Cut", 1, true));
+			menu->AddItem(ContextMenuItem("Copy", 0, true));
+			menu->AddItem(ContextMenuItem("Paste", 2, true));
+		}
+		else
+		{
+			menu->RemoveItem(0);
+			menu->RemoveItem(1);
+			menu->RemoveItem(2);
+			menu->AddItem(ContextMenuItem("Paste", 2, true));
+		}
+	}
 	if (button != SDL_BUTTON_RIGHT)
 	{
 		mouseDown = true;


### PR DESCRIPTION
Regarding issue https://github.com/The-Powder-Toy/The-Powder-Toy/issues/720

Made cut and copy buttons disappear when no text is selected in a Textbox as suggested by @LBPHacker.