### PR TITLE
Fix label menu show when nothing is selected

### DIFF
--- a/src/gui/interface/Label.cpp
+++ b/src/gui/interface/Label.cpp
@@ -91,7 +91,7 @@ void Label::OnMouseClick(int x, int y, unsigned button)
 {
 	if(button == SDL_BUTTON_RIGHT)
 	{
-		if (menu)
+		if (menu && HasSelection())
 		{
 			menu->Show(GetScreenPos() + ui::Point(x, y));
 		}


### PR DESCRIPTION
Fixing one more issue because issue https://github.com/The-Powder-Toy/The-Powder-Toy/issues/720 has been reopened.
