### PR TITLE
DTEC upgradation

### DIFF
--- a/src/simulation/Element.cpp
+++ b/src/simulation/Element.cpp
@@ -257,6 +257,21 @@ bool Element::ctypeDrawVInTmp(CTYPEDRAW_FUNC_ARGS)
 	return true;
 }
 
+bool Element::ctypeDrawVInpavg(CTYPEDRAW_FUNC_ARGS)
+{
+	if (!Element::basicCtypeDraw(CTYPEDRAW_FUNC_SUBCALL_ARGS))
+	{
+		return false;
+	}
+	if (t == PT_LIFE)
+	{
+		sim->parts[i].pavg[0] = v;
+	}
+	return true;
+}
+
+
+
 bool Element::ctypeDrawVInCtype(CTYPEDRAW_FUNC_ARGS)
 {
 	if (!Element::basicCtypeDraw(CTYPEDRAW_FUNC_SUBCALL_ARGS))

--- a/src/simulation/Element.h
+++ b/src/simulation/Element.h
@@ -69,6 +69,7 @@ public:
 	static int legacyUpdate(UPDATE_FUNC_ARGS);
 	static bool basicCtypeDraw(CTYPEDRAW_FUNC_ARGS);
 	static bool ctypeDrawVInTmp(CTYPEDRAW_FUNC_ARGS);
+	static bool ctypeDrawVInpavg(CTYPEDRAW_FUNC_ARGS);
 	static bool ctypeDrawVInCtype(CTYPEDRAW_FUNC_ARGS);
 
 	/** Returns a list of properties, their type and offset within the structure that can be changed


### PR DESCRIPTION
Move GoL elements from .tmp to .pavg
Add support for invert mode and serialisation to FILT.

Todo:
Add a compatibility check for older versions.
Make it show the GoL name in HUD? (HUD doesn't support pavg currently)
Add .deserialisation support?