### PR TITLE
Add thorium element

### DIFF
--- a/src/simulation/elements/NEUT.cpp
+++ b/src/simulation/elements/NEUT.cpp
@@ -93,6 +93,18 @@ static int update(UPDATE_FUNC_ARGS)
 						Element_FIRE_update(UPDATE_FUNC_SUBCALL_ARGS);
 					}
 					break;
+				case PT_THOR:
+					if (RNG::Ref().chance(1, 5000))
+					{
+						sim->create_part(ID(r), x+rx, y+ry, PT_NEUT);
+						sim->pv[y/CELL][x/CELL] += 1.0f * CFDS;
+					} else if(RNG::Ref().chance(1, 10000)){
+						sim->create_part(ID(r), x+rx, y+ry, PT_ELEC);
+					}
+					else if(RNG::Ref().chance(1, 100)){
+						parts[ID(r)].life+=30;
+					}
+					break;
 #ifdef SDEUT
 				case PT_DEUT:
 					if (RNG::Ref().chance(pressureFactor + 1 + (parts[ID(r)].life/100), 1000))

--- a/src/simulation/elements/THOR.cpp
+++ b/src/simulation/elements/THOR.cpp
@@ -1,0 +1,57 @@
+#include "simulation/ElementCommon.h"
+
+static int update(UPDATE_FUNC_ARGS);
+
+void Element::Element_THOR()
+{
+	Identifier = "DEFAULT_PT_THOR";
+	Name = "THOR";
+	Colour = PIXPACK(0x728d91);
+	MenuVisible = 1;
+	MenuSection = SC_NUCLEAR;
+	Enabled = 1;
+
+	Advection = 0.4f;
+	AirDrag = 0.01f * CFDS;
+	AirLoss = 0.99f;
+	Loss = 0.95f;
+	Collision = 0.0f;
+	Gravity = 0.4f;
+	Diffusion = 0.00f;
+	HotAir = 0.000f	* CFDS;
+	Falldown = 1;
+
+	Flammable = 0;
+	Explosive = 0;
+	Meltable = 0;
+	Hardness = 0;
+	PhotonReflectWavelengths = 0x001FCE00;
+
+	Weight = 90;
+
+	DefaultProperties.temp = R_TEMP + 4.0f + 273.15f;
+	HeatConduct = 251;
+	Description = "Thorium. Heavy, fissile particles. Reacts to neutrons.";
+
+	Properties = TYPE_PART|PROP_NEUTPASS|PROP_RADIOACTIVE|PROP_LIFE_DEC;
+
+	LowPressure = IPL;
+	LowPressureTransition = NT;
+	HighPressure = IPH;
+	HighPressureTransition = NT;
+	LowTemperature = ITL;
+	LowTemperatureTransition = NT;
+	HighTemperature = ITH;
+	HighTemperatureTransition = NT;
+
+	Update = &update;
+}
+
+static int update(UPDATE_FUNC_ARGS)
+{
+	if (RNG::Ref().chance(1, 50000) | (parts[i].life % 30 == 1)){
+	    sim->create_part(-1, x, y, PT_NEUT);
+	    parts[i].temp += 3000;
+	}
+	return 0;
+}

--- a/src/simulation/elements/meson.build
+++ b/src/simulation/elements/meson.build
@@ -191,6 +191,7 @@ simulation_elem_ids = [
 	[ 'VSNS',   189 ],
 	[ 'ROCK',   190 ],
 	[ 'LITH',   191 ],
+	[ 'THOR',   192 ],
 ]
 
 simulation_elem_src = []


### PR DESCRIPTION
Works somewhat like PLUT, but has both prompt and delayed radiation, allowing the reaction to be somewhat controlled. Unlike PLUT it doesn't react to pressure (though it does create pressure). The reaction rate is only influenced by the amount of NEUT passing. This allows for neat things such as using moderators or reflectors to tweak the speed of reaction.