### PR TITLE
Enable fighters to choose a random fighter to fight.

### DIFF
--- a/src/simulation/elements/FIGH.cpp
+++ b/src/simulation/elements/FIGH.cpp
@@ -96,11 +96,11 @@ static int update(UPDATE_FUNC_ARGS)
 		tary = (int)sim->player.legs[3];
 		parts[i].tmp2 = 1;
 	}
-	else
+	else if (sim->fighcount > 1)
 	{
 		playerst fighRand[MAX_FIGHTERS];
 		std::copy(std::begin(sim->fighters), std::end(sim->fighters), std::begin(fighRand));
-		std::random_shuffle(&fighRand[0], &fighRand[sim->fighcount - 1]);
+		std::random_shuffle(&fighRand[0], &fighRand[sim->fighcount]);
 		if (&fighRand[0] != figh && ((pow((float)figh->legs[2] - x, 2) + pow((float)figh->legs[3] - y, 2)) <=
 			pow((float)fighRand[0].legs[2] - x, 2) + pow((float)fighRand[0].legs[3] - y, 2)))
 		{

--- a/src/simulation/elements/FIGH.cpp
+++ b/src/simulation/elements/FIGH.cpp
@@ -96,6 +96,19 @@ static int update(UPDATE_FUNC_ARGS)
 		tary = (int)sim->player.legs[3];
 		parts[i].tmp2 = 1;
 	}
+	else
+	{
+		playerst fighRand[MAX_FIGHTERS];
+		std::copy(std::begin(sim->fighters), std::end(sim->fighters), std::begin(fighRand));
+		std::random_shuffle(&fighRand[0], &fighRand[sim->fighcount - 1]);
+		if (&fighRand[0] != figh && ((pow((float)figh->legs[2] - x, 2) + pow((float)figh->legs[3] - y, 2)) <=
+			pow((float)fighRand[0].legs[2] - x, 2) + pow((float)fighRand[0].legs[3] - y, 2)))
+		{
+			tarx = (int)fighRand[0].legs[2];
+			tary = (int)fighRand[0].legs[3];
+			parts[i].tmp2 = 1;
+		}
+	}
 
 	switch (parts[i].tmp2)
 	{


### PR DESCRIPTION
Hi, I really like this project, but one of the things I feel that's left out is the ability for fighters to fight eachother. Unlike Powder Game, the fighters just stood there when there are no players to fight.

This modification enables fighters to fight each other. How this works is that the fighter will choose another random fighter in the simulation if there is any. If so, it will fight the closest fighter next to it. If there's a player 1 or player 2 stickman, some will choose the player as high priority and others will continue fighting.

While not exactly like the original Powder Game, it works decently well enough.

![jT7Zehqvp1](https://user-images.githubusercontent.com/5020096/117088107-5e64b780-ad06-11eb-85f2-0c3d06136a37.gif)
![PeMmDvnRXr](https://user-images.githubusercontent.com/5020096/117088108-5efd4e00-ad06-11eb-8bf2-560c97db370a.gif)

