### PR TITLE
Adjust color of LITH

### DIFF
--- a/src/simulation/elements/LITH.cpp
+++ b/src/simulation/elements/LITH.cpp
@@ -7,7 +7,7 @@ void Element::Element_LITH()
 {
 	Identifier = "DEFAULT_PT_LITH";
 	Name = "LITH";
-	Colour = PIXPACK(0xC5C5BB);
+	Colour = PIXPACK(0xb6aabf);
 	MenuVisible = 1;
 	MenuSection = SC_EXPLOSIVE;
 	Enabled = 1;

--- a/src/simulation/elements/LITH.cpp
+++ b/src/simulation/elements/LITH.cpp
@@ -7,7 +7,7 @@ void Element::Element_LITH()
 {
 	Identifier = "DEFAULT_PT_LITH";
 	Name = "LITH";
-	Colour = PIXPACK(0xb6aabf);
+	Colour = PIXPACK(0xB6AABF);
 	MenuVisible = 1;
 	MenuSection = SC_EXPLOSIVE;
 	Enabled = 1;


### PR DESCRIPTION
Takes a slight bit of artistic liberty, makes LITH faintly purple. Lithium in the real world doesn't look this way, but Potassium, a closely related element, does.
![image](https://user-images.githubusercontent.com/7806367/124378994-2af8c780-dc7a-11eb-821c-4e350469c9f2.png)
