### PR TITLE
Prevent ROCK from repeatedly breaking into STNE and reforming under pressure

### DIFF
--- a/src/simulation/elements/FIRE.cpp
+++ b/src/simulation/elements/FIRE.cpp
@@ -131,7 +131,7 @@ int Element_FIRE_update(UPDATE_FUNC_ARGS)
 				}
 			}
 		}
-		else if ((parts[i].ctype == PT_STNE || !parts[i].ctype) && sim->pv[y / CELL][x / CELL] >= 30.0f) // Form ROCK with pressure
+		else if ((parts[i].ctype == PT_STNE || !parts[i].ctype) && sim->pv[y / CELL][x / CELL] >= 30.0f && (parts[i].temp > 1943.15f || sim->pv[y / CELL][x / CELL] < 120.0f)) // Form ROCK with pressure, if it will stay molten or not immediately break
 		{
 			parts[i].tmp2 = RNG::Ref().between(0, 10); // Provide tmp2 for color noise
 			parts[i].ctype = PT_ROCK;


### PR DESCRIPTION
Found something where the ROCK reactions can cause an infinite loop of ROCK breaking into STNE, melting, and reforming ROCK. Having molten stone turn into rock if it will just break again seems pointless.
Video [here](https://co10.cf/img/rock_stne_loop.mp4) (Not sure how other browsers handle that, sorry if it doesn't work)

Changed molten stone to only turn into rock if it will stay molten, or will not break from pressure.