### PR TITLE
Add optional GNOME-styled icon

### DIFF
--- a/resources/icon/styled-unused/README.md
+++ b/resources/icon/styled-unused/README.md
@@ -1,0 +1,57 @@
+# Styled Icons
+
+This directory contains artwork along with platform-specific templates and icons for optional use by downstream distributors.
+
+This README reflects the current contents of this directory. If you add to or update the contents of this directory, please update this README accordingly.
+
+## Icon Components
+
+There are three subfolders here:
+
+1. **Templates:** these files can be used with SVG artwork to create icons styled for different desktop environments.
+2. **Contents:** these files are SVG artwork that can be used with different templates for different desktop environments.
+3. **Composites:** these files are "contents" files that have already been combined with "templates" files.
+
+> **Note:** at present the macOS Big Sur icon template does not have top-edge glow, but it would probably look better if it had one. I just haven't figured out how to do it manually in SVG, yet.
+
+## Editing and Conversion
+
+These SVG files were created out of raw XML in VS Code with [a particular SVG preview](https://marketplace.visualstudio.com/items?itemName=jock.svg) extension. Not all SVG extensions support all the features of SVG. Because these were written in raw XML, you may create mangled syntax if you try to edit them in a graphical editor. The best editor for not mangling the handwritten syntax *too much* is [Inkscape](https://inkscape.org/), which uses SVG natively and therefore will not lose quality due to format conversion. You should probably save your work under a different filename, though.
+
+The files use a nominal resolution of 32px x 32px in order to keep the pixel grid easy to visualize. For some desktop environments, you may need to export from SVG to PNG. On Linux, you can create 1024px x 1024px PNGs using ImageMagick with the following command:
+
+```bash
+$ convert -density 3072 -background none <filename>.svg <filename>.png
+```
+
+(Other renderers may support a different subset of SVG features, so you may need to experiment to get the correct result elsewhere.)
+
+## Tweaking "Fireball" Layouts
+
+Where the "contents" files use "fireballs", these fireballs are simple radial gradients that are scaled and overlaid on each other, with specific CSS blending modes and filters applied.
+
+* To move and resize the fireballs, find the tags labeled `<use xlink:href="#fireball" />`. `translate(<x> <y>)` represents the coordinates of the center of the fireball, and `scale(<num>)` is the scale factor (the prototype fireball being 1.5px x 1.25px). These values do not have to be whole numbers, but I used whole numbers to keep the code more legible.
+
+* The "haze" effect comes from a filter translating [Perlin noise](https://en.wikipedia.org/wiki/Perlin_noise) into localized displacement. I used [the example from the MDN](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/feTurbulence), if you want to play around with the parameters.
+
+* The fireballs in the directories at this point use the "lighten" [blending mode](https://en.wikipedia.org/wiki/Blend_modes). The blending mode used by The Powder Toy (e.g. in the historical icon) seems to be the ["color dodge" blending mode](https://en.wikipedia.org/wiki/Blend_modes#Dodge_and_burn). With the corrent color gradients, the "color dodge" blending mode is a bit burnt out, but you might get better results if you change the gradient values. You can find a full list of CSS blend modes [at the MDN here](https://developer.mozilla.org/en-US/docs/Web/CSS/blend-mode).
+
+* The fireball gradient at present is made up of simple ratios of red and yellow. Colors along the [Planckian locus](https://en.wikipedia.org/wiki/Planckian_locus) may be more accurate, but the more cartoonish colors seem to be a better match for the colors used by The Powder Toy.
+
+* At present, the gradient is applied to the fireball prototypes, which are then scaled. The gradient scales with each fireball, which may not be the best representation of how the heat glow of an actual fireball is distributed. For example, the gradient may maintain the same absolute scale aropund the perimeter of the fireball's silhouette, or it may scale logarithmically, idk. Long story short, you may get more realistic results if you copy the gradient code into each fireball separately and tweak the gradient stops to better reflect the fireball's scale. This could be automated in JavaScript, but I really didn't feel like going down the rabbit hole of beginning to create a physics simulation within the icon itself.
+
+* There are XML comments within the SVG files themselves with some more explanation around how they work and how to work with them.
+
+## Credits
+
+GNOME "monitor" frame taken from [GNOME Terminal](https://gitlab.gnome.org/GNOME/gnome-terminal/blob/master/data/icons/hicolor_apps_scalable_org.gnome.Terminal.svg)
+
+Fireballs and compositing by [Elsie Hupp](https://github.com/elsiehupp/), 2021.
+
+(Add your name here if you contribute further.)
+
+## License
+
+SVG files containing elements of the GNOME Terminal icon are GPL-3, per [GNOME Terminal](https://gitlab.gnome.org/GNOME/gnome-terminal/).
+
+Everything else is also GPL-3, per [The Powder Toy](https://github.com/The-Powder-Toy/The-Powder-Toy) as a whole.

--- a/resources/icon/styled-unused/composites/fireballs_filtered_gnome.svg
+++ b/resources/icon/styled-unused/composites/fireballs_filtered_gnome.svg
@@ -1,0 +1,187 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 32 32" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+
+    <use xlink:href="#bezel" mask="url(#screen-cutout)" />
+    <use xlink:href="#screen" transform="translate(3, 6)" mask="url(#screen-mask)"/>
+
+    <defs>
+
+        <mask id="screen-cutout">
+            <rect width="100" height="100%" fill="white" />
+            <use xlink:href="#screen-rect" transform="translate(3,6)" fill="black" />
+        </mask>
+
+        <mask id="screen-mask">
+            <use xlink:href="#screen-rect" fill="white" />
+        </mask>
+
+        <rect id="screen-rect" width="26" height="18" rx="1" ry="1" />
+
+        <svg id="bezel">
+
+            <rect id="bottom" x="2" y="5" width="28" height="22" rx="2" ry="2" fill="url(#edge-gradient)" />
+            <rect id="front" x="2" y="5" width="28" height="20" rx="2" ry="2" fill="#deddda"/>
+
+            <defs>
+
+                 <linearGradient id="edge-gradient">
+
+                    <stop offset="0.000000" stop-color="rgb(119,118,123)"/>
+                    <stop offset="0.046875" stop-color="rgb(192,191,188)"/>
+                    <stop offset="0.093750" stop-color="rgb(154,153,150)"/>
+                    <stop offset="0.906250" stop-color="rgb(154,153,150)"/>
+                    <stop offset="0.953125" stop-color="rgb(192,191,188)"/>
+                    <stop offset="1.000000" stop-color="rgb(119,118,123)"/>
+
+                </linearGradient>
+
+            </defs>
+
+        </svg>
+
+        <svg id="screen">
+
+            <rect id="background" width="100%" height="100%" fill="#241F31"/>
+
+            <g id="viewport" transform="translate(1,1)" mask="url(#viewport-mask)">
+
+                <use xlink:href="#fireballs" transform="translate(0,-4) scale(0.6875)" style="filter:url(#displacementFilter);" />
+
+            </g>
+
+            <g id="buttons">
+
+                <use x="1" y="16" xlink:href="#button-small" />
+                <use x="3" y="16" xlink:href="#button-small" />
+                <use x="5" y="16" xlink:href="#button-medium" />
+                <use x="9" y="16" xlink:href="#button-wide" />
+                <use x="16" y="16" xlink:href="#button-medium" />
+                <use x="20" y="16" xlink:href="#button-small" />
+                <use x="22" y="16" xlink:href="#button-small" />
+
+                <use x="24" y="1" xlink:href="#button-small" />
+                <use x="24" y="4" xlink:href="#button-small" />
+                <use x="24" y="7" xlink:href="#button-small" />
+                <use x="24" y="10" xlink:href="#button-small" />
+                <use x="24" y="13" xlink:href="#button-small" />
+                <use x="24" y="16" xlink:href="#button-small" />
+
+            </g>
+
+            <defs>
+
+                <svg id="button-small">
+                    <use xlink:href="#button" />
+                </svg>
+
+                <svg id="button-medium">
+                    <use xlink:href="#button" transform="scale(3,1)" />
+                </svg>
+
+                <svg id="button-wide">
+                    <use xlink:href="#button" transform="scale(6,1)" />
+                </svg>
+
+                <rect id="button" width="1" height="1" fill="rgb(222, 221, 218)" />
+
+                <mask id="viewport-mask">
+                    <rect id="viewport-rect" width="22" height="14" fill="white" />
+                </mask>
+
+                <svg
+                    id="fireballs"
+                    width="100%"
+                    height="100%"
+                    viewBox="0 0 32 32" >
+
+
+                    <!-- Each fireball is an instance with a transform using whole numbers. -->
+                    <!-- This nested scaling makes it easier to mentally visualize the picture. -->
+
+                    <use xlink:href="#fireball"
+
+                        id="left"
+                        transform="
+                            translate(9 17)
+                            scale(7)
+                        " />
+
+                    <use xlink:href="#fireball"
+
+                        id="top"
+                        transform="
+                            translate(15 12)
+                            scale(8)
+                        " />
+
+                    <use xlink:href="#fireball"
+
+                        id="right"
+                        transform="
+                            translate(23 15)
+                            scale(5)
+                        " />
+
+                    <use xlink:href="#fireball"
+
+                        id="bottom"
+                        transform="
+                            translate(17 20)
+                            scale(7)
+                        " />
+
+                    <use xlink:href="#fireball"
+
+                        id="center-left"
+                        transform="
+                            translate(13 15)
+                            scale(10)
+                        " />
+
+                    <use xlink:href="#fireball"
+
+                        id="center-right"
+                        transform="
+                            translate(19 17)
+                            scale(11)
+                        "/>
+
+                    <defs>
+
+                        <radialGradient id="radial" cx="0" cy="0" r="0.5" gradientTransform="translate(0.5 0.5)">
+
+                            <!-- The gradient colors are based on simple ratios of red and yellow. -->
+                            <!-- For more realism, though, they could hypothetically
+                                follow blackbody radiation color temperatures -->
+
+                            <stop offset="0.00" stop-color="#FFF" stop-opacity="1.00" />
+                            <stop offset="0.18" stop-color="#FFB" stop-opacity="0.98" />
+                            <stop offset="0.37" stop-color="#FF0" stop-opacity="0.93" />
+                            <stop offset="0.57" stop-color="#F80" stop-opacity="0.80" />
+                            <stop offset="0.68" stop-color="#F00" stop-opacity="0.48" />
+                            <stop offset="0.86" stop-color="#F00" stop-opacity="0.14" />
+                            <stop offset="1.00" stop-color="#F00" stop-opacity="0.00" />
+
+                        </radialGradient>
+
+                        <filter id="displacementFilter">
+                            <feTurbulence type="turbulence" baseFrequency="1"
+                                numOctaves="99" result="turbulence"/>
+                            <feDisplacementMap in2="turbulence" in="SourceGraphic"
+                                scale="1.5" xChannelSelector="R" yChannelSelector="G"/>
+                        </filter>
+
+                        <ellipse id="fireball" cx="0" cy="0" rx="1.5" ry="1.25" fill="url(#radial)" style="mix-blend-mode:lighten;"/>
+
+                    </defs>
+
+                </svg>
+
+            </defs>
+
+        </svg>
+
+    </defs>
+
+</svg>

--- a/resources/icon/styled-unused/composites/fireballs_no_filter_gnome.svg
+++ b/resources/icon/styled-unused/composites/fireballs_no_filter_gnome.svg
@@ -1,0 +1,180 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 32 32" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+
+    <use xlink:href="#bezel" mask="url(#screen-cutout)" />
+    <use xlink:href="#screen" transform="translate(3, 6)" mask="url(#screen-mask)"/>
+
+    <defs>
+
+        <mask id="screen-cutout">
+            <rect width="100" height="100%" fill="white" />
+            <use xlink:href="#screen-rect" transform="translate(3,6)" fill="black" />
+        </mask>
+
+        <mask id="screen-mask">
+            <use xlink:href="#screen-rect" fill="white" />
+        </mask>
+
+        <rect id="screen-rect" width="26" height="18" rx="1" ry="1" />
+
+        <svg id="bezel">
+
+            <rect id="bottom" x="2" y="5" width="28" height="22" rx="2" ry="2" fill="url(#edge-gradient)" />
+            <rect id="front" x="2" y="5" width="28" height="20" rx="2" ry="2" fill="#deddda"/>
+
+            <defs>
+
+                 <linearGradient id="edge-gradient">
+
+                    <stop offset="0.000000" stop-color="rgb(119,118,123)"/>
+                    <stop offset="0.046875" stop-color="rgb(192,191,188)"/>
+                    <stop offset="0.093750" stop-color="rgb(154,153,150)"/>
+                    <stop offset="0.906250" stop-color="rgb(154,153,150)"/>
+                    <stop offset="0.953125" stop-color="rgb(192,191,188)"/>
+                    <stop offset="1.000000" stop-color="rgb(119,118,123)"/>
+
+                </linearGradient>
+
+            </defs>
+
+        </svg>
+
+        <svg id="screen">
+
+            <rect id="background" width="100%" height="100%" fill="#241F31"/>
+
+            <g id="viewport" transform="translate(1,1)" mask="url(#viewport-mask)">
+
+                <use xlink:href="#fireballs" transform="translate(0,-4) scale(0.6875)" />
+
+            </g>
+
+            <g id="buttons">
+
+                <use x="1" y="16" xlink:href="#button-small" />
+                <use x="3" y="16" xlink:href="#button-small" />
+                <use x="5" y="16" xlink:href="#button-medium" />
+                <use x="9" y="16" xlink:href="#button-wide" />
+                <use x="16" y="16" xlink:href="#button-medium" />
+                <use x="20" y="16" xlink:href="#button-small" />
+                <use x="22" y="16" xlink:href="#button-small" />
+
+                <use x="24" y="1" xlink:href="#button-small" />
+                <use x="24" y="4" xlink:href="#button-small" />
+                <use x="24" y="7" xlink:href="#button-small" />
+                <use x="24" y="10" xlink:href="#button-small" />
+                <use x="24" y="13" xlink:href="#button-small" />
+                <use x="24" y="16" xlink:href="#button-small" />
+
+            </g>
+
+            <defs>
+
+                <svg id="button-small">
+                    <use xlink:href="#button" />
+                </svg>
+
+                <svg id="button-medium">
+                    <use xlink:href="#button" transform="scale(3,1)" />
+                </svg>
+
+                <svg id="button-wide">
+                    <use xlink:href="#button" transform="scale(6,1)" />
+                </svg>
+
+                <rect id="button" width="1" height="1" fill="rgb(222, 221, 218)" />
+
+                <mask id="viewport-mask">
+                    <rect id="viewport-rect" width="22" height="14" fill="white" />
+                </mask>
+
+                <svg
+                    id="fireballs"
+                    width="100%"
+                    height="100%"
+                    viewBox="0 0 32 32" >
+
+
+                    <!-- Each fireball is an instance with a transform using whole numbers. -->
+                    <!-- This nested scaling makes it easier to mentally visualize the picture. -->
+
+                    <use xlink:href="#fireball"
+
+                        id="left"
+                        transform="
+                            translate(9 17)
+                            scale(7)
+                        " />
+
+                    <use xlink:href="#fireball"
+
+                        id="top"
+                        transform="
+                            translate(15 12)
+                            scale(8)
+                        " />
+
+                    <use xlink:href="#fireball"
+
+                        id="right"
+                        transform="
+                            translate(23 15)
+                            scale(5)
+                        " />
+
+                    <use xlink:href="#fireball"
+
+                        id="bottom"
+                        transform="
+                            translate(17 20)
+                            scale(7)
+                        " />
+
+                    <use xlink:href="#fireball"
+
+                        id="center-left"
+                        transform="
+                            translate(13 15)
+                            scale(10)
+                        " />
+
+                    <use xlink:href="#fireball"
+
+                        id="center-right"
+                        transform="
+                            translate(19 17)
+                            scale(11)
+                        "/>
+
+                    <defs>
+
+                        <radialGradient id="radial" cx="0" cy="0" r="0.5" gradientTransform="translate(0.5 0.5)">
+
+                            <!-- The gradient colors are based on simple ratios of red and yellow. -->
+                            <!-- For more realism, though, they could hypothetically
+                                follow blackbody radiation color temperatures -->
+
+                            <stop offset="0.00" stop-color="#FFF" stop-opacity="1.00" />
+                            <stop offset="0.18" stop-color="#FFB" stop-opacity="0.98" />
+                            <stop offset="0.37" stop-color="#FF0" stop-opacity="0.93" />
+                            <stop offset="0.57" stop-color="#F80" stop-opacity="0.80" />
+                            <stop offset="0.68" stop-color="#F00" stop-opacity="0.48" />
+                            <stop offset="0.86" stop-color="#F00" stop-opacity="0.14" />
+                            <stop offset="1.00" stop-color="#F00" stop-opacity="0.00" />
+
+                        </radialGradient>
+
+                        <ellipse id="fireball" cx="0" cy="0" rx="1.5" ry="1.25" fill="url(#radial)" style="mix-blend-mode:lighten;"/>
+
+                    </defs>
+
+                </svg>
+
+            </defs>
+
+        </svg>
+
+    </defs>
+
+</svg>

--- a/resources/icon/styled-unused/composites/raster_gnome_128.svg
+++ b/resources/icon/styled-unused/composites/raster_gnome_128.svg
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 32 32" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+
+    <g transform="scale(1)">
+        <use xlink:href="#bezel" mask="url(#screen-cutout)" />
+        <use xlink:href="#screen" transform="translate(3, 6)" mask="url(#screen-mask)"/>
+    </g>
+
+    <defs>
+
+        <mask id="screen-cutout">
+            <rect width="100" height="100%" fill="white" />
+            <use xlink:href="#screen-rect" transform="translate(3,6)" fill="black" />
+        </mask>
+
+        <mask id="screen-mask">
+            <use xlink:href="#screen-rect" fill="white" />
+        </mask>
+
+        <rect id="screen-rect" width="26" height="18" rx="1" ry="1" />
+
+        <svg id="bezel">
+
+            <rect id="bottom" x="2" y="5" width="28" height="22" rx="2" ry="2" fill="url(#edge-gradient)" />
+            <rect id="front" x="2" y="5" width="28" height="20" rx="2" ry="2" fill="#deddda"/>
+
+            <defs>
+
+                 <linearGradient id="edge-gradient">
+
+                    <stop offset="0.000000" stop-color="rgb(119,118,123)"/>
+                    <stop offset="0.046875" stop-color="rgb(192,191,188)"/>
+                    <stop offset="0.093750" stop-color="rgb(154,153,150)"/>
+                    <stop offset="0.906250" stop-color="rgb(154,153,150)"/>
+                    <stop offset="0.953125" stop-color="rgb(192,191,188)"/>
+                    <stop offset="1.000000" stop-color="rgb(119,118,123)"/>
+
+                </linearGradient>
+
+            </defs>
+
+        </svg>
+
+        <svg id="screen">
+
+            <rect id="background" width="100%" height="100%" fill="#241F31"/>
+
+            <image id="raster" x="1" y="1" width="22" height="14" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAFoAAAA6CAYAAAAwXE5YAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAOLklEQVR4nO2cWXMcuZHHf6iqrj7ZbFIHpZFm7HX42Kd1+Nv7G2zsR3DYuw/2znhGIkX2WTewD5nZhaZIiaI03rGnMwJR3XWggD8SeQCZBUf6h5ADCBAOzibAAJhqOQXOgRfAa+BXwL/r7zNgBgyB9HOa4YAR8AS4ABb6/6HkgRrYAH+G7h00ASpgByyBS+AaWOu5Bul5ooWoCrt/rfdZM9H/K63rLfAGaO9uVQdk4LI7ryZArv0ca5khoF4AL7U8RwYiixr6yWQAT5HRHSCgxY2x+25T0HutpMAJhK+hC1C/E0A3CGBb5P8OKBBQgz420Fd5fZUHSr231XOJHms919EP1EfofaBT7fcJMNfjKcJoXwG/BL7R/xNt4F0YPIhyrWiOTIlEmzTWhrjoaC+xY0B66pFeV/of8AFaJ6cKepCNg9FHSi3o63Otroiu7bRqtHmp1rNGBrDkkC/uofeBzhEApwgXm9h4jgD9CuHqGZ8B8kIrUA7kBOkpWmGmJY2Ki4pHEHP0LOWga6EupVRDKE+hqGBX9hzcRY8b2K1ey7UJNT3XNtE91rQWGYBSr38y0BnCzRM9GmdfIAB/hQB+qrg8CmSTO2NtcUYvNqCfy5meM7lk85aoZx37gfAJVB28fQfbtVY1g2IExQDKQq43oRcPCT3gHcK5LjpnEskGpIuaGM+OQw13J/VAm8gYcyibT4BniCJ8hoAcz+wPUo6AFRCWOgF+jQANwhY+qjDQc6qBnUaIBAhxAYKDkECbwo2D7wpYryHNIZ9CncPKw7YWoGsFyYBEj7FizOhFfha9vqGXyzG4DwY6VUzGCKcOEbBniPhcIADP9HzGR0AeaCUmFjxwA3yNCPnn2mJT6bn2puNQwxjbKVv5GroG2hbaThRe66WUNVxv4bKCVSV1JIkAu66gaHvO7ejFRdtXT0tvOTlt1pRe3BA9Y+Amt56JcfHsZ4EAbRZGDPKUXiFO9ZzhcSfI9sYcMU+eIqMzomeJp8C/6XWzkSp6brbemhDVloYWfAntGppCQK1qKDsphYdtC+sSlrUqqUruKVrYhV7GQi97TUrdBskhvDLjUFXkCnSJTFCTfJPoGZvpZm1u5b4e6NsAnyoexs0n9Nx8J43pDe2nOkLjW28/Q0yWE23tFSI+Yk6OBWMF3Va4t62gLqDeirIrFcRtC5sO1i3sGigdtAOoKti18ppaq4zFvZUhkLhenBhgiRPrpQ69vjIz0cw5m4QmbkZRV80Q2gLfGWz2QnNOzhCr61wxe6LnJtzjlJwgYuF3EdALfSCn1zAnen2irR7TewWGhCnFGrolVDsBtWzUalCE2kzkcqOgli00CaQpDFXcpJ28PgYwpZ/SiYPpFJKRTiaV+0kCQUVS3UBdwbwRJ8ZmdBbxhjXbLDGT55Xy0x7oGb08PkOU3nN6BXhO7/29Z5yfK8i/uQX0nN7QRns30QqHCrSNsMlqU3wNsIVQQsggRFZI2ik3tmpKdwq+g6YDlwpI3RiaVq77ClwLAw+JKlLvIB3B+FQUZ+eg85FB46HxqkAb2BUwXwnXrhVEEz8GvIkas2Bq9ja4AL1QZlsg3Puc3gp7QS9q3/MAnyEy99fAbxXsVzpaU4SdbAoEer8+Nt0W0dDXiPBbAjtdCsjBTQSkTpVjMgDfwiTAzMPZCJqp2NG+E0uEIXujN2zAFQK2My3mpJ7BWBzkgIiKoMK6873833WwG8LGwYulNNGcGgMcepO3iUA+APoZwoDPEFv5tR4vFHjzJ1LAxXLmF7dA/pWOjAn0WNPEQ2/mW65Am7+7At6x9x6SIQzmkCUQhhAm7FV+COC9gGO6M3TQ1GLuJWNIh+BqxOLZilKlA6d6wAGJzqJg7XQCtgcqL0BvPOxqcYK8Ez1RtFCE3qU3x8WsGQO5iIG+GAqgL53oqtcOnmewGMA0haGDzIlM26vZMx2Rb+4YmSEfdxtNgxjZGoe1spV73AjclN49MwdH52gIOviZ/O4qOSYppE5RuGav/kMDzhCIV4vMvEDaERyMBzJrpo04PN1M2tMtVSG3oj92lSjijb7GuL3ouyiHVxfwMoHXqTDpywxOxzA8gWwsU8yl2iFb2hshMuZrRMbElsa9NuADgB8jXJ4jQs8WFAyUGTKgI3ruzOR+5yBtINTgTButEY7W1SFXaZ0reosn0fpssBvpbzYVxZgXMF2KCOKJ6A5fQreDdgXVJazWcOnh2maA76Xj/vDb38HLIbzIBfDzAYwm4Aw441AzKG0tYqFgP0eU4phDLv1UoM1DMBVunGeLFKmef6bvMk/CxFCicriOnt1Gg2XnbUnPWM/EoQFdST/cQqyYdAODd/qM6ZG1lHAD7QQmN5BVMNzBeidO0ibsl3AEld//BzydwXwIkxTygSgg5tox88vNqzGtGBvgdu2xdJurzAaLV4FsitusITofe5Jm1E4RZjDtZDPD6jTu7uiXC+z8ABGPiYJ6pccamQ1XwKWIkmwMsxlkSzi5hmULNzWsgkymPdDf/B5OZjDMIU1k2ux9cFthGtJzd7zQEXfy0eulUR02I+5bTLjvPXF7TNbactztpTprs5qRtjy/N7JNF8z1vp3+3tK7e1eIuFyBW0F6DZNLGFzC4C3k72C8grGYJdKr+R8gz2WaOOvIgH6UrREmPh69yv8Rcvf8/hJ1xOsm9t8jjBNvs9g6t4kTG3zzv01hv6IXSytwV+C+g8HfYfotZN/D9BLmW+DvCvTwlyL0XdyweCrGa8H/rGT9iOzovVtn/41MHFkxA8CW7Uy0NYi8XiEe7kS8zDyDLIVRCpMreqDT2Y/WvZ8W3WYWA/FjZEbAbTLZbtfUHXQdpAFSD+kOeLyJcCSg1wemv+b0e1tBf78BjkB/JsUe7hQxce1cQKyUM+AI9GeSiR4TH8bZA8RyuUYskyPQX4BMxscxC7Z7+xRxrn48O+1nSvFa0AIB+QI4Av0jkHm4tu58vj97pC9KJrMn9DsqRxl9B92OHXjMKqRtodsa0BHoW2Sen0XKxBsXn0JxXIps5R1FxwHZ4pPFhHUfvv3BdR45Wsk4OQbZuPJBIVn31NlhGxZHoIE+PqCOiq3ePSDe64N1boGj6LiH4qDKx65YGkfXwJGjleI1i5TD8KMvszSsQMdrtD9HMqBv78w/ZpM5JpP7+1ptBH+uQMOX39iINwb2MtqCyI70Zcjks4U7vKcMj2B/PsU5NVtsG1yB/lfYE/ypkIUrbJEYwmtgD3SIypE+j8x+LpA16QM7Os4VONLnUewRWnS7WR2h1Li6eFf4KEYeT3GYhpCadzfRTXelmx3p4WSuu0V4CeMK0M0bzfXpwJl3FJc4WfpIH6Y4nK7PnxSgr7+VGODhiaQZJBYCFScd2sbjkT5Mtm9owZ8S+ClAf/tXeLaC0wmMMsgG4GYatnuOBJf/s3H1h5T77aDJ2/SlRKZFvhrQf/sBmhUUOcwzGA9hNIPBOSQ1fZCj4/Hrs/8IindILLmk4/24OgvbjWMy4DBX8tO+ieG935cQAs5VJGlBUM9Qgb6G9Q2cpfBkAOdjWMxgvoNRy2G67AeTDf+fyQIQC8RRuEEAj2eiDYIGm3OO9MksBYuptnMPeGsIeO8py5KmafDekyQrBvkPDPI/AYbYX6/gqoEzB8shbMdQT9inpQ0ySDpNVzijz93+sSyT2w6Ui87H+cRxwLqda5BQ2jf0CaOR1xtaydCiRPSOfQ/DuPtc6znlMMPhwzPZe09d11RVhfeeNN2BuybN/gLsgf4epq14jOuBpHpVE+hOJE9jXsJorZGRDYcf6/jSYEepyQexzBbPXNJ/gMOi+M0DMwC39BxdcPAdD3MmnCV+W+51hsRivNL6LhCGmmj5cNqIcbUVnMf7hhBi0fHdDzDpYO1g6+SzC9UE2hNoN5KFtFjDqNGB9fSZsfEXCAyomBMtDtlWCOM1lXBHMY5Vr2r/JQMn6W5hC/5SckfYagKPrimEtV434LfgSs1paSQPMQSJA0+c9MN5yXLIRpBegPuNtq1GuHpBH5j/PtAGcNd1hHC/ApYnry4lMd0SFYsMqrEkuNc7qNdQt3CWSTpcXiEixHJc4pxCm8ZEjbNYNEv4iSPrbcp3UVFODZVkvbadpvwGzQe/gm4Ffg1hBazALzUpfwntTrxdalHmWS2ZWl0jg5WkkA4gbSUDdwIsxjBbw2CCxMyNtQ+WHfb+109CCLRtS9u21HW9V4T3A71c9smrBbBLodTE9m0Jmwo2CbwewIWH2Y2A7M7BPVUzUL+TEyxXBG1sDlQQrqTjLsp+cqqUgoIaZ0OGAvxW0svKCrZBMlc3DWwKKLcK9kY42FdQFbBZQrUV7o2zIhyRNOog6/qwiyfALwr4agXTFbillrGauZXqJ2MgmZHee9q2pihKqkqABo9zLc5VWuJwg5UCnCN6ZNPBZgerAq7XcF3AdStfEFju4PQNpFPIzyF/AdlCWuwb6XC3E451mmUVCpnuNJBMJSM2dcJNvoR2K4mYtgPdVdCV+iWDlXyux4BeeVhWUBRQ30C7BF8IiKXvM91s08g+HeI4/EKF6bghkr23QQbxbAODa8jnkp2WaxJ/3krb90sUAnbXdTRNR9sKxzu3I03fkg3+TDb4b5yrIqA39KLTcoTGwFWANxV8/xb+dwn/8w6evoH5DKZjOD2DxTP5QoADmp2AU24F9NSJPPQlVPppgOEC8hnkI8gy4bzNVr4gEFrJ8W5aKBopZQO1h9rJJx12Day2sHsHRS3XunC4OmmMZ2axJfGaWW3qIkXExjnwtwS+CvCkgMWlZA2f1qKbzi9hMRffYu8l63RwFvalEUnpNfnwvxiN/0g++M+frsvxr0r/B5JA+ApD0NYwAAAAAElFTkSuQmCC"/>
+
+            <g id="buttons">
+
+                <use x="1" y="16" xlink:href="#button-small" />
+                <use x="3" y="16" xlink:href="#button-small" />
+                <use x="5" y="16" xlink:href="#button-medium" />
+                <use x="9" y="16" xlink:href="#button-wide" />
+                <use x="16" y="16" xlink:href="#button-medium" />
+                <use x="20" y="16" xlink:href="#button-small" />
+                <use x="22" y="16" xlink:href="#button-small" />
+
+                <use x="24" y="1" xlink:href="#button-small" />
+                <use x="24" y="4" xlink:href="#button-small" />
+                <use x="24" y="7" xlink:href="#button-small" />
+                <use x="24" y="10" xlink:href="#button-small" />
+                <use x="24" y="13" xlink:href="#button-small" />
+                <use x="24" y="16" xlink:href="#button-small" />
+
+            </g>
+
+            <defs>
+
+                <svg id="button-small">
+                    <use xlink:href="#button" />
+                </svg>
+
+                <svg id="button-medium">
+                    <use xlink:href="#button" transform="scale(3,1)" />
+                </svg>
+
+                <svg id="button-wide">
+                    <use xlink:href="#button" transform="scale(6,1)" />
+                </svg>
+
+                <rect id="button" width="1" height="1" fill="rgb(222, 221, 218)" />
+
+            </defs>
+
+        </svg>
+
+    </defs>
+
+</svg>

--- a/resources/icon/styled-unused/composites/raster_gnome_32.svg
+++ b/resources/icon/styled-unused/composites/raster_gnome_32.svg
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 32 32" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+
+    <g transform="scale(1)">
+        <use xlink:href="#bezel" mask="url(#screen-cutout)" />
+        <use xlink:href="#screen" transform="translate(3, 6)" mask="url(#screen-mask)"/>
+    </g>
+
+    <defs>
+
+        <mask id="screen-cutout">
+            <rect width="100" height="100%" fill="white" />
+            <use xlink:href="#screen-rect" transform="translate(3,6)" fill="black" />
+        </mask>
+
+        <mask id="screen-mask">
+            <use xlink:href="#screen-rect" fill="white" />
+        </mask>
+
+        <rect id="screen-rect" width="26" height="18" rx="1" ry="1" />
+
+        <svg id="bezel">
+
+            <rect id="bottom" x="2" y="5" width="28" height="22" rx="2" ry="2" fill="url(#edge-gradient)" />
+            <rect id="front" x="2" y="5" width="28" height="20" rx="2" ry="2" fill="#deddda"/>
+
+            <defs>
+
+                 <linearGradient id="edge-gradient">
+
+                    <stop offset="0.000000" stop-color="rgb(119,118,123)"/>
+                    <stop offset="0.046875" stop-color="rgb(192,191,188)"/>
+                    <stop offset="0.093750" stop-color="rgb(154,153,150)"/>
+                    <stop offset="0.906250" stop-color="rgb(154,153,150)"/>
+                    <stop offset="0.953125" stop-color="rgb(192,191,188)"/>
+                    <stop offset="1.000000" stop-color="rgb(119,118,123)"/>
+
+                </linearGradient>
+
+            </defs>
+
+        </svg>
+
+        <svg id="screen">
+
+            <rect id="background" width="100%" height="100%" fill="#241F31"/>
+
+            <image id="raster" x="1" y="1" width="22" height="14" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAQCAYAAAAMJL+VAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAB0UlEQVQ4jbXUu05UQRwG8N85LAuLSswmooGseDfBxkQrTeyJIWphw0toZecjWOkT+AJ2FjZaWJIYI2IM63oJIOEOu9x22TMW5yxsqDSsXzKZ2z/zXWYy/GdEECLBEMbwBMOtHShgEJfQh4RQZX2CDxt8RB1lVDCPKUIgJsqB4xjBfZxFFKGI07hxoCVpsFnl9wZTMb9yLO2xiC1pv4wcAvbSIRdxB9cQ5zMrDzCQqS7TnGPlPauzlNep5inkudDL1RPsJpTWmdwhTg/3uhXRs1LwsJ/Bk3RdwaMWW6Z+FROEH4QiSUzYIqoQzaQlzW7WFqlO8f2n8HlT/DjNQqi9DY4VcSbLq7ftcJnfZpq/XHZBCbazVs/Wq5im+U6YeSU+N53eZOgomiGEckiSp8EhmR1CjPMY3Z91AIk0pnaSoU4SNKTPph27aD1TTXQdgaDn0DxgBfsO6tliJzHXRrDwhuST1OrfYi+rr0sTOEAIhFBEK6LnL7g3zPVxcrccWA5tfZ2QkMxn6iYJC0S7xCWiUZTQpVarqTe+tBG8fMdkgfEKN8fou0xjM/3UunuoL7A9x+wS3yqsVVhbJl9PM7g9wEiDU3c19avVdvQWvv5DGkfAH1PC+QLcT9lrAAAAAElFTkSuQmCC"/>
+
+            <g id="buttons">
+
+                <use x="1" y="16" xlink:href="#button-small" />
+                <use x="3" y="16" xlink:href="#button-small" />
+                <use x="5" y="16" xlink:href="#button-medium" />
+                <use x="9" y="16" xlink:href="#button-wide" />
+                <use x="16" y="16" xlink:href="#button-medium" />
+                <use x="20" y="16" xlink:href="#button-small" />
+                <use x="22" y="16" xlink:href="#button-small" />
+
+                <use x="24" y="1" xlink:href="#button-small" />
+                <use x="24" y="4" xlink:href="#button-small" />
+                <use x="24" y="7" xlink:href="#button-small" />
+                <use x="24" y="10" xlink:href="#button-small" />
+                <use x="24" y="13" xlink:href="#button-small" />
+                <use x="24" y="16" xlink:href="#button-small" />
+
+            </g>
+
+            <defs>
+
+                <svg id="button-small">
+                    <use xlink:href="#button" />
+                </svg>
+
+                <svg id="button-medium">
+                    <use xlink:href="#button" transform="scale(3,1)" />
+                </svg>
+
+                <svg id="button-wide">
+                    <use xlink:href="#button" transform="scale(6,1)" />
+                </svg>
+
+                <rect id="button" width="1" height="1" fill="rgb(222, 221, 218)" />
+
+            </defs>
+
+        </svg>
+
+    </defs>
+
+</svg>

--- a/resources/icon/styled-unused/composites/simple_fireball_gnome.svg
+++ b/resources/icon/styled-unused/composites/simple_fireball_gnome.svg
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 32 32" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+
+    <g mask="url(#clipping-mask)">
+        <!-- The contents of the viewport should be scaled to size here -->
+        <use xlink:href="#contents" width="100%" height="100%"/>
+    </g>
+
+    <use xlink:href="#edge-overlay"/>
+
+    <defs>
+
+        <rect id="outline" x="3" y="3" width="26" height="26" rx="2" ry="2" />
+
+        <mask id="clipping-mask">
+            <use xlink:href="#outline" fill="white" />
+        </mask>
+
+        <svg id="edge-overlay">
+
+            <use xlink:href="#outline" fill="url(#edge-gradient)" mask="url(#edge-mask)" style="mix-blend-mode:multiply;"/>
+
+            <defs>
+
+                <mask id="edge-mask">
+
+                    <use xlink:href="#outline" fill="white" />
+                    <use xlink:href="#outline" y="-1" fill="black" />
+
+                </mask>
+
+                <linearGradient id="edge-gradient">
+
+                    <stop offset="0.00" stop-color="rgb(119,118,123)"/>
+                    <stop offset="0.04" stop-color="rgb(192,191,188)"/>
+                    <stop offset="0.08" stop-color="rgb(154,153,150)"/>
+                    <stop offset="0.92" stop-color="rgb(154,153,150)"/>
+                    <stop offset="0.96" stop-color="rgb(192,191,188)"/>
+                    <stop offset="1.00" stop-color="rgb(119,118,123)"/>
+
+                </linearGradient>
+
+            </defs>
+
+        </svg>
+
+        <svg
+            id="contents"
+            width="100%"
+            height="100%"
+            viewBox="0 0 32 32">
+
+            <rect id="background" width="100%" height="100%" fill="#241F31" />
+            <ellipse id="fireball" cx="13" cy="32" rx="100%" ry="100%" fill="url(#radial)" style="filter:url(#displacementFilter);mix-blend-mode:lighten;"/>
+
+            <defs>
+
+                <radialGradient id="radial" cx="0" cy="0" r="0.5" gradientTransform="translate(0.5 0.5)">
+                    <stop offset="0.00" stop-color="#FFF" stop-opacity="1.00" />
+                    <stop offset="0.10" stop-color="#FFB" stop-opacity="1.00" />
+                    <stop offset="0.30" stop-color="#FF0" stop-opacity="0.80" />
+                    <stop offset="0.50" stop-color="#F80" stop-opacity="0.70" />
+                    <stop offset="0.60" stop-color="#F00" stop-opacity="0.50" />
+                    <stop offset="0.70" stop-color="#F00" stop-opacity="0.10" />
+                    <stop offset="0.80" stop-color="#F00" stop-opacity="0.00" />
+                </radialGradient>
+
+                <filter id="displacementFilter">
+                    <feTurbulence type="turbulence" baseFrequency=".1"
+                        numOctaves="7" result="turbulence"/>
+                    <feDisplacementMap in2="turbulence" in="SourceGraphic"
+                        scale="12" xChannelSelector="R" yChannelSelector="G"/>
+                </filter>
+
+            </defs>
+
+        </svg>
+
+    </defs>
+
+</svg>

--- a/resources/icon/styled-unused/composites/simple_fireball_mac.svg
+++ b/resources/icon/styled-unused/composites/simple_fireball_mac.svg
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 32 32" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+
+    <use xlink:href="#outline" fill="black" style="filter:url(#drop-shadow)" />
+
+    <g mask="url(#clipping-mask)">
+        <use xlink:href="#contents"/>
+    </g>
+
+    <!-- <use xlink:href="#outline" fill="black" style="filter:url(#inner-glow)" /> -->
+
+    <defs>
+
+        <path id="outline" d="M14.656,3.125L11.168,3.138C10.861,3.138 10.555,3.138 10.248,3.139C9.99,3.141 9.732,3.144 9.474,3.151C8.911,3.166 8.344,3.199 7.788,3.299C7.224,3.4 6.699,3.565 6.186,3.825C5.682,4.081 5.221,4.416 4.822,4.814C4.422,5.213 4.087,5.673 3.83,6.175C3.569,6.687 3.404,7.211 3.302,7.774C3.202,8.329 3.169,8.894 3.154,9.455C3.147,9.712 3.144,9.97 3.143,10.227C3.141,10.533 3.125,10.913 3.125,11.219L3.125,17.344L3.141,20.857C3.141,21.163 3.141,21.469 3.143,21.775C3.144,22.033 3.147,22.291 3.154,22.549C3.169,23.111 3.202,23.677 3.302,24.233C3.404,24.796 3.569,25.321 3.83,25.833C4.087,26.336 4.422,26.797 4.822,27.196C5.221,27.595 5.682,27.93 6.186,28.186C6.699,28.447 7.224,28.612 7.789,28.714C8.345,28.813 8.912,28.846 9.474,28.862C9.732,28.869 9.99,28.872 10.248,28.873C10.555,28.875 10.861,28.875 11.168,28.875L20.864,28.875C21.17,28.875 21.476,28.875 21.781,28.873C22.039,28.872 22.297,28.869 22.554,28.862C23.116,28.846 23.682,28.813 24.237,28.713C24.8,28.612 25.324,28.447 25.836,28.186C26.338,27.93 26.799,27.595 27.198,27.196C27.596,26.797 27.931,26.336 28.187,25.833C28.447,25.321 28.613,24.796 28.714,24.232C28.814,23.677 28.847,23.11 28.862,22.549C28.869,22.291 28.872,22.033 28.873,21.775C28.875,21.469 28.875,21.163 28.875,20.857L28.875,11.145C28.875,10.839 28.875,10.533 28.873,10.227C28.872,9.97 28.869,9.712 28.862,9.455C28.847,8.894 28.814,8.328 28.714,7.773C28.613,7.211 28.447,6.687 28.187,6.175C27.931,5.673 27.596,5.213 27.198,4.814C26.799,4.416 26.339,4.081 25.836,3.826C25.324,3.565 24.8,3.4 24.236,3.299C23.681,3.199 23.115,3.166 22.554,3.151C22.297,3.144 22.039,3.141 21.781,3.139C21.476,3.138 21.17,3.138 20.864,3.138L17.312,3.125L14.656,3.125Z" />
+
+        <mask id="clipping-mask">
+            <use xlink:href="#outline" fill="white" />
+        </mask>
+
+        <filter id="drop-shadow">
+            <feOffset result="offOut" in="SourceGraphic" dx="0" dy="0.3" />
+            <feGaussianBlur result="blurOut" in="offOut" stdDeviation=".3" />
+            <feBlend in="SourceGraphic" in2="blurOut" mode="normal" />
+        </filter>
+
+        <!-- I haven't figured out the upper-edge glow, yet. -->
+        <!-- <filter id="inner-glow">
+            <feFlood result="floodFill" flood-color="white"/>
+            <feOffset result="offOut" in="floodFill" dx="0" dy="0.3" />
+            <feGaussianBlur result="blurOut" in="offOut" stdDeviation="1"/>
+            <feBlend in="SourceGraphic" in2="blurOut" mode="lighten" />
+            <feComposite operator="atop" in2="SourceGraphic"/>
+        </filter> -->
+
+        <svg
+            id="contents"
+            width="100%"
+            height="100%"
+            viewBox="0 0 32 32">
+
+            <rect id="background" width="100%" height="100%" fill="#241F31" />
+            <ellipse id="fireball" cx="13" cy="32" rx="100%" ry="100%" fill="url(#radial)" style="filter:url(#displacementFilter);mix-blend-mode:lighten;"/>
+
+            <defs>
+
+                <radialGradient id="radial" cx="0" cy="0" r="0.5" gradientTransform="translate(0.5 0.5)">
+                    <stop offset="0.00" stop-color="#FFF" stop-opacity="1.00" />
+                    <stop offset="0.10" stop-color="#FFB" stop-opacity="1.00" />
+                    <stop offset="0.30" stop-color="#FF0" stop-opacity="0.80" />
+                    <stop offset="0.50" stop-color="#F80" stop-opacity="0.70" />
+                    <stop offset="0.60" stop-color="#F00" stop-opacity="0.50" />
+                    <stop offset="0.70" stop-color="#F00" stop-opacity="0.10" />
+                    <stop offset="0.80" stop-color="#F00" stop-opacity="0.00" />
+                </radialGradient>
+
+                <filter id="displacementFilter">
+                    <feTurbulence type="turbulence" baseFrequency=".1"
+                        numOctaves="7" result="turbulence"/>
+                    <feDisplacementMap in2="turbulence" in="SourceGraphic"
+                        scale="12" xChannelSelector="R" yChannelSelector="G"/>
+                </filter>
+
+            </defs>
+
+        </svg>
+
+    </defs>
+
+</svg>

--- a/resources/icon/styled-unused/contents/fireballs_filtered.svg
+++ b/resources/icon/styled-unused/contents/fireballs_filtered.svg
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
+    width="100%"
+    height="100%"
+    viewBox="0 0 32 32">
+
+    <rect id="background" width="100%" height="100%" fill="#241F31"/>
+
+    <!-- Each fireball is an instance with a transform using whole numbers. -->
+    <!-- This nested scaling makes it easier to mentally visualize the picture. -->
+
+    <g filter="url(#displacementFilter)">
+
+    <use xlink:href="#fireball"
+
+        id="left"
+        transform="
+            translate(9 17)
+            scale(7)
+        " />
+
+    <use xlink:href="#fireball"
+
+        id="top"
+        transform="
+            translate(15 12)
+            scale(8)
+        " />
+
+    <use xlink:href="#fireball"
+
+        id="right"
+        transform="
+            translate(23 15)
+            scale(5)
+        " />
+
+    <use xlink:href="#fireball"
+
+        id="bottom"
+        transform="
+            translate(17 20)
+            scale(7)
+        " />
+
+    <use xlink:href="#fireball"
+
+        id="center-left"
+        transform="
+            translate(13 15)
+            scale(10)
+        " />
+
+    <use xlink:href="#fireball"
+
+        id="center-right"
+        transform="
+            translate(19 17)
+            scale(11)
+        "/>
+
+    </g>
+
+    <defs>
+
+        <radialGradient id="radial" cx="0" cy="0" r="0.5" gradientTransform="translate(0.5 0.5)">
+
+            <!-- The gradient colors are based on simple ratios of red and yellow. -->
+            <!-- For more realism, though, they could hypothetically
+                follow blackbody radiation color temperatures -->
+
+            <stop offset="0.00" stop-color="#FFF" stop-opacity="1.00" />
+            <stop offset="0.18" stop-color="#FFB" stop-opacity="0.98" />
+            <stop offset="0.37" stop-color="#FF0" stop-opacity="0.93" />
+            <stop offset="0.57" stop-color="#F80" stop-opacity="0.80" />
+            <stop offset="0.68" stop-color="#F00" stop-opacity="0.48" />
+            <stop offset="0.86" stop-color="#F00" stop-opacity="0.14" />
+            <stop offset="1.00" stop-color="#F00" stop-opacity="0.00" />
+
+        </radialGradient>
+
+        <filter id="displacementFilter">
+            <feTurbulence type="turbulence" baseFrequency="1"
+                numOctaves="99" result="turbulence"/>
+            <feDisplacementMap in2="turbulence" in="SourceGraphic"
+                scale="1.5" xChannelSelector="R" yChannelSelector="G"/>
+        </filter>
+
+        <ellipse id="fireball" cx="0" cy="0" rx="1.5" ry="1.25" fill="url(#radial)" style="mix-blend-mode:lighten;" />
+
+    </defs>
+
+</svg>

--- a/resources/icon/styled-unused/contents/fireballs_no_filter.svg
+++ b/resources/icon/styled-unused/contents/fireballs_no_filter.svg
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
+    width="100%"
+    height="100%"
+    viewBox="0 0 32 32">
+
+    <rect id="background" width="100%" height="100%" fill="#241F31"/>
+
+    <!-- Each fireball is an instance with a transform using whole numbers. -->
+    <!-- This nested scaling makes it easier to mentally visualize the picture. -->
+
+    <use xlink:href="#fireball"
+
+        id="left"
+        transform="
+            translate(9 17)
+            scale(7)
+        " />
+
+    <use xlink:href="#fireball"
+
+        id="top"
+        transform="
+            translate(15 12)
+            scale(8)
+        " />
+
+    <use xlink:href="#fireball"
+
+        id="right"
+        transform="
+            translate(23 15)
+            scale(5)
+        " />
+
+    <use xlink:href="#fireball"
+
+        id="bottom"
+        transform="
+            translate(17 20)
+            scale(7)
+        " />
+
+    <use xlink:href="#fireball"
+
+        id="center-left"
+        transform="
+            translate(13 15)
+            scale(10)
+        " />
+
+    <use xlink:href="#fireball"
+
+        id="center-right"
+        transform="
+            translate(19 17)
+            scale(11)
+        "/>
+
+    <defs>
+
+        <radialGradient id="radial" cx="0" cy="0" r="0.5" gradientTransform="translate(0.5 0.5)">
+
+            <!-- The gradient colors are based on simple ratios of red and yellow. -->
+            <!-- For more realism, though, they could hypothetically
+                follow blackbody radiation color temperatures -->
+
+            <stop offset="0.00" stop-color="#FFF" stop-opacity="1.00" />
+            <stop offset="0.18" stop-color="#FFB" stop-opacity="0.98" />
+            <stop offset="0.37" stop-color="#FF0" stop-opacity="0.93" />
+            <stop offset="0.57" stop-color="#F80" stop-opacity="0.80" />
+            <stop offset="0.68" stop-color="#F00" stop-opacity="0.48" />
+            <stop offset="0.86" stop-color="#F00" stop-opacity="0.14" />
+            <stop offset="1.00" stop-color="#F00" stop-opacity="0.00" />
+
+        </radialGradient>
+
+        <ellipse id="fireball" cx="0" cy="0" rx="1.5" ry="1.25" fill="url(#radial)" style="mix-blend-mode:lighten;" />
+
+    </defs>
+
+</svg>

--- a/resources/icon/styled-unused/contents/simple_fireball.svg
+++ b/resources/icon/styled-unused/contents/simple_fireball.svg
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 32 32" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+
+    <rect id="background" width="100%" height="100%" fill="#241F31" />
+    <ellipse id="fireball" cx="13" cy="32" rx="100%" ry="100%" fill="url(#radial)" style="filter:url(#displacementFilter);mix-blend-mode:lighten;"/>
+
+    <defs>
+
+        <radialGradient id="radial" cx="0" cy="0" r="0.5" gradientTransform="translate(0.5 0.5)">
+            <stop offset="0.00" stop-color="#FFF" stop-opacity="1.00" />
+            <stop offset="0.10" stop-color="#FFB" stop-opacity="1.00" />
+            <stop offset="0.30" stop-color="#FF0" stop-opacity="0.80" />
+            <stop offset="0.50" stop-color="#F80" stop-opacity="0.70" />
+            <stop offset="0.60" stop-color="#F00" stop-opacity="0.50" />
+            <stop offset="0.70" stop-color="#F00" stop-opacity="0.10" />
+            <stop offset="0.80" stop-color="#F00" stop-opacity="0.00" />
+        </radialGradient>
+
+        <filter id="displacementFilter">
+            <feTurbulence type="turbulence" baseFrequency=".1"
+                numOctaves="7" result="turbulence"/>
+            <feDisplacementMap in2="turbulence" in="SourceGraphic"
+                scale="12" xChannelSelector="R" yChannelSelector="G"/>
+        </filter>
+
+    </defs>
+
+</svg>
+
+</svg>

--- a/resources/icon/styled-unused/templates/empty_frame_gnome.svg
+++ b/resources/icon/styled-unused/templates/empty_frame_gnome.svg
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 32 32" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+
+    <use xlink:href="#bezel" mask="url(#screen-cutout)" />
+    <use xlink:href="#screen" transform="translate(3, 6)" mask="url(#screen-mask)"/>
+
+    <defs>
+
+        <mask id="screen-cutout">
+            <rect width="100" height="100%" fill="white" />
+            <use xlink:href="#screen-rect" transform="translate(3,6)" fill="black" />
+        </mask>
+
+        <mask id="screen-mask">
+            <use xlink:href="#screen-rect" fill="white" />
+        </mask>
+
+        <rect id="screen-rect" width="26" height="18" rx="1" ry="1" />
+
+        <svg id="bezel">
+
+            <rect id="bottom" x="2" y="5" width="28" height="22" rx="2" ry="2" fill="url(#edge-gradient)" />
+            <rect id="front" x="2" y="5" width="28" height="20" rx="2" ry="2" fill="#deddda"/>
+
+            <defs>
+
+                 <linearGradient id="edge-gradient">
+
+                    <stop offset="0.000000" stop-color="rgb(119,118,123)"/>
+                    <stop offset="0.046875" stop-color="rgb(192,191,188)"/>
+                    <stop offset="0.093750" stop-color="rgb(154,153,150)"/>
+                    <stop offset="0.906250" stop-color="rgb(154,153,150)"/>
+                    <stop offset="0.953125" stop-color="rgb(192,191,188)"/>
+                    <stop offset="1.000000" stop-color="rgb(119,118,123)"/>
+
+                </linearGradient>
+
+            </defs>
+
+        </svg>
+
+        <svg id="screen">
+
+            <rect id="background" width="100%" height="100%" fill="#241F31"/>
+
+            <g id="viewport" transform="translate(1,1)" mask="url(#viewport-mask)">
+
+                <!-- The contents of the viewport should be scaled to size, centered, and cropped to landscape -->
+                <use xlink:href="#contents" transform="translate(0,-9)" width="22"/>
+
+            </g>
+
+            <g id="buttons">
+
+                <use x="1" y="16" xlink:href="#button-small" />
+                <use x="3" y="16" xlink:href="#button-small" />
+                <use x="5" y="16" xlink:href="#button-medium" />
+                <use x="9" y="16" xlink:href="#button-wide" />
+                <use x="16" y="16" xlink:href="#button-medium" />
+                <use x="20" y="16" xlink:href="#button-small" />
+                <use x="22" y="16" xlink:href="#button-small" />
+
+                <use x="24" y="1" xlink:href="#button-small" />
+                <use x="24" y="4" xlink:href="#button-small" />
+                <use x="24" y="7" xlink:href="#button-small" />
+                <use x="24" y="10" xlink:href="#button-small" />
+                <use x="24" y="13" xlink:href="#button-small" />
+                <use x="24" y="16" xlink:href="#button-small" />
+
+            </g>
+
+            <defs>
+
+                <svg id="button-small">
+                    <use xlink:href="#button" />
+                </svg>
+
+                <svg id="button-medium">
+                    <use xlink:href="#button" transform="scale(3,1)" />
+                </svg>
+
+                <svg id="button-wide">
+                    <use xlink:href="#button" transform="scale(6,1)" />
+                </svg>
+
+                <rect id="button" width="1" height="1" fill="rgb(222, 221, 218)" />
+
+                <mask id="viewport-mask">
+                    <rect id="viewport-rect" width="22" height="14" fill="white" />
+                </mask>
+
+                <svg
+                    id="contents"
+                    width="100%"
+                    height="100%"
+                    viewBox="0 0 32 32">
+
+                    <!-- This rectanlge is the background of the contents below.
+                    It's magenta to make it clearer in the preview, but you'll probably want to change it. -->
+                    <rect id="background" width="100%" height="100%" fill="magenta"/>
+
+                    <!-- Put whatever you want here.
+                    You can change the vewBox size above, but the cropping and scaling
+                    will only work correctly if the width and height are identical (i.e. square). -->
+            </defs>
+        </svg>
+
+
+
+    </defs>
+
+</svg>

--- a/resources/icon/styled-unused/templates/empty_outline_gnome_landscape.svg
+++ b/resources/icon/styled-unused/templates/empty_outline_gnome_landscape.svg
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 32 32" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+
+    <g mask="url(#clipping-mask)">
+        <!-- The contents of the viewport should be scaled to size, centered, and cropped to landscape -->
+        <use xlink:href="#contents" y="-2" width="100%"/>
+    </g>
+
+    <use xlink:href="#edge-overlay"/>
+
+    <defs>
+
+        <rect id="outline" x="2" y="4" width="28" height="24" rx="2" ry="2" />
+
+        <mask id="clipping-mask">
+            <use xlink:href="#outline" fill="white" />
+        </mask>
+
+        <svg id="edge-overlay">
+
+            <use xlink:href="#outline" fill="url(#edge-gradient)" mask="url(#edge-mask)" style="mix-blend-mode:multiply;"/>
+
+            <defs>
+
+                <mask id="edge-mask">
+
+                    <use xlink:href="#outline" fill="white" />
+                    <use xlink:href="#outline" y="-1" fill="black" />
+
+                </mask>
+
+                <linearGradient id="edge-gradient">
+
+                    <!-- Note that the gradient stops are fractions
+                    that line up with the pixel grid at 32px x 32px.
+                    Here the gradient is 28px long (the width of "outline"),
+                    with 2px at either end for the curved corners. -->
+                    <stop offset="0.000000" stop-color="rgb(119,118,123)"/>
+                    <stop offset="0.046875" stop-color="rgb(192,191,188)"/>
+                    <stop offset="0.093750" stop-color="rgb(154,153,150)"/>
+                    <stop offset="0.906250" stop-color="rgb(154,153,150)"/>
+                    <stop offset="0.953125" stop-color="rgb(192,191,188)"/>
+                    <stop offset="1.000000" stop-color="rgb(119,118,123)"/>
+
+                </linearGradient>
+
+            </defs>
+
+        </svg>
+
+        <svg
+            id="contents"
+            width="100%"
+            height="100%"
+            viewBox="0 0 32 32">
+
+            <!-- This rectanglee is the background of the contents below.
+            It's magenta to make it clearer in the preview, but you'll probably want to change it. -->
+            <rect id="background" width="100%" height="100%" fill="magenta" />
+
+            <!-- Put whatever you want here.
+            You can change the vewBox size above, but the cropping and scaling
+            will only work correctly if the width and height are identical (i.e. square). -->
+
+        </svg>
+
+    </defs>
+
+</svg>

--- a/resources/icon/styled-unused/templates/empty_outline_gnome_square.svg
+++ b/resources/icon/styled-unused/templates/empty_outline_gnome_square.svg
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 32 32" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+
+    <g mask="url(#clipping-mask)">
+        <!-- The contents of the viewport should be scaled to size here -->
+        <use xlink:href="#contents" width="100%" height="100%"/>
+    </g>
+
+    <use xlink:href="#edge-overlay"/>
+
+    <defs>
+
+        <rect id="outline" x="3" y="3" width="26" height="26" rx="2" ry="2" />
+
+        <mask id="clipping-mask">
+            <use xlink:href="#outline" fill="white" />
+        </mask>
+
+        <svg id="edge-overlay">
+
+            <use xlink:href="#outline" fill="url(#edge-gradient)" mask="url(#edge-mask)" style="mix-blend-mode:multiply;"/>
+
+            <defs>
+
+                <mask id="edge-mask">
+
+                    <use xlink:href="#outline" fill="white" />
+                    <use xlink:href="#outline" y="-1" fill="black" />
+
+                </mask>
+
+                <linearGradient id="edge-gradient">
+
+                    <!-- Note that the gradient stops are fractions
+                    that line up with the pixel grid at 32px x 32px.
+                    Here the gradient is 26px long (the width of "outline"),
+                    with 2px at either end for the curved corners. -->
+                    <stop offset="0.00" stop-color="rgb(119,118,123)"/>
+                    <stop offset="0.04" stop-color="rgb(192,191,188)"/>
+                    <stop offset="0.08" stop-color="rgb(154,153,150)"/>
+                    <stop offset="0.92" stop-color="rgb(154,153,150)"/>
+                    <stop offset="0.96" stop-color="rgb(192,191,188)"/>
+                    <stop offset="1.00" stop-color="rgb(119,118,123)"/>
+
+                </linearGradient>
+
+            </defs>
+
+        </svg>
+
+        <svg
+            id="contents"
+            width="100%"
+            height="100%"
+            viewBox="0 0 32 32">
+
+            <!-- This rectanglee is the background of the contents below.
+            It's magenta to make it clearer in the preview, but you'll probably want to change it. -->
+            <rect id="background" width="100%" height="100%" fill="magenta" />
+
+            <!-- Put whatever you want here.
+            You can change the vewBox size above, but the cropping and scaling
+            will only work correctly if the width and height are identical (i.e. square). -->
+
+        </svg>
+
+    </defs>
+
+</svg>

--- a/resources/icon/styled-unused/templates/empty_outline_mac.svg
+++ b/resources/icon/styled-unused/templates/empty_outline_mac.svg
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 32 32" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+
+    <use xlink:href="#squircle" fill="black" style="filter:url(#drop-shadow)" />
+    <!-- <use xlink:href="#squircle" fill="black" style="filter:url(#inner-glow)" /> -->
+
+    <g mask="url(#clipping-mask)">
+        <use xlink:href="#contents"/>
+    </g>
+
+    <defs>
+
+        <path id="squircle" d="M14.656,3.125L11.168,3.138C10.861,3.138 10.555,3.138 10.248,3.139C9.99,3.141 9.732,3.144 9.474,3.151C8.911,3.166 8.344,3.199 7.788,3.299C7.224,3.4 6.699,3.565 6.186,3.825C5.682,4.081 5.221,4.416 4.822,4.814C4.422,5.213 4.087,5.673 3.83,6.175C3.569,6.687 3.404,7.211 3.302,7.774C3.202,8.329 3.169,8.894 3.154,9.455C3.147,9.712 3.144,9.97 3.143,10.227C3.141,10.533 3.125,10.913 3.125,11.219L3.125,17.344L3.141,20.857C3.141,21.163 3.141,21.469 3.143,21.775C3.144,22.033 3.147,22.291 3.154,22.549C3.169,23.111 3.202,23.677 3.302,24.233C3.404,24.796 3.569,25.321 3.83,25.833C4.087,26.336 4.422,26.797 4.822,27.196C5.221,27.595 5.682,27.93 6.186,28.186C6.699,28.447 7.224,28.612 7.789,28.714C8.345,28.813 8.912,28.846 9.474,28.862C9.732,28.869 9.99,28.872 10.248,28.873C10.555,28.875 10.861,28.875 11.168,28.875L20.864,28.875C21.17,28.875 21.476,28.875 21.781,28.873C22.039,28.872 22.297,28.869 22.554,28.862C23.116,28.846 23.682,28.813 24.237,28.713C24.8,28.612 25.324,28.447 25.836,28.186C26.338,27.93 26.799,27.595 27.198,27.196C27.596,26.797 27.931,26.336 28.187,25.833C28.447,25.321 28.613,24.796 28.714,24.232C28.814,23.677 28.847,23.11 28.862,22.549C28.869,22.291 28.872,22.033 28.873,21.775C28.875,21.469 28.875,21.163 28.875,20.857L28.875,11.145C28.875,10.839 28.875,10.533 28.873,10.227C28.872,9.97 28.869,9.712 28.862,9.455C28.847,8.894 28.814,8.328 28.714,7.773C28.613,7.211 28.447,6.687 28.187,6.175C27.931,5.673 27.596,5.213 27.198,4.814C26.799,4.416 26.339,4.081 25.836,3.826C25.324,3.565 24.8,3.4 24.236,3.299C23.681,3.199 23.115,3.166 22.554,3.151C22.297,3.144 22.039,3.141 21.781,3.139C21.476,3.138 21.17,3.138 20.864,3.138L17.312,3.125L14.656,3.125Z" />
+
+        <mask id="clipping-mask">
+            <use xlink:href="#squircle" fill="white" />
+        </mask>
+
+        <filter id="drop-shadow">
+            <feOffset result="offOut" in="SourceGraphic" dx="0" dy="0.3" />
+            <feGaussianBlur result="blurOut" in="offOut" stdDeviation=".3" />
+            <feBlend in="SourceGraphic" in2="blurOut" mode="normal" />
+        </filter>
+
+        <!-- I haven't figured out the upper-edge glow, yet. -->
+        <!-- <filter id="inner-glow">
+            <feFlood result="floodFill" flood-color="white"/>
+            <feOffset result="offOut" in="floodFill" dx="0" dy="0.3" />
+            <feGaussianBlur result="blurOut" in="offOut" stdDeviation="1"/>
+            <feBlend in="SourceGraphic" in2="blurOut" mode="lighten" />
+            <feComposite operator="atop" in2="SourceGraphic"/>
+        </filter> -->
+
+        <svg
+            id="contents"
+            width="100%"
+            height="100%"
+            viewBox="0 0 32 32">
+
+            <!-- This rectanglee is the background of the contents below.
+            It's magenta to make it clearer in the preview, but you'll probably want to change it. -->
+            <rect id="background" width="100%" height="100%" fill="magenta"/>
+
+            <!-- Put whatever you want here.
+            You can change the vewBox size above, but the cropping and scaling
+            will only work correctly if the width and height are identical (i.e. square). -->
+
+        </svg>
+
+    </defs>
+
+</svg>


### PR DESCRIPTION
I [made this on a whim](https://github.com/MrCarroll/the-powder-toy-snap/pull/2) a while back, but this is probably the better place to post it.

This is literally just the existing icon with the "chrome" replaced with [the frame from gnome-terminal](https://gitlab.gnome.org/GNOME/gnome-terminal/blob/master/data/icons/hicolor_apps_scalable_org.gnome.Terminal.svg).

Screenshot from the `tpt icon` simulation:

<img width="65" alt="screenshot from the tpt icon simulation" src="https://user-images.githubusercontent.com/9206310/106204412-ea58c780-618a-11eb-8639-e1a7002754d1.png">

...cropped, with the "chrome" replaced:
![screenshot cropped, with the "chrome" replaced](https://user-images.githubusercontent.com/9206310/106204309-c72e1800-618a-11eb-9a2c-78334893522c.png)

I see that you have other disused icons, so I figure that adding this one to the repository as a template of sorts for platform-specific styled icons wouldn’t hurt. (I don’t know how the packaging here works, though, so I don’t know what would be involved in an end user picking an optional icon, aside from manually switching it out.) Like, for comparison, it doesn’t seem like there’s a macOS Big-Sur-style icon, either.