### PR TITLE
Fix WARP particles not getting highlighted when using find mode

### DIFF
--- a/src/simulation/elements/WARP.cpp
+++ b/src/simulation/elements/WARP.cpp
@@ -88,7 +88,7 @@ static int update(UPDATE_FUNC_ARGS)
 static int graphics(GRAPHICS_FUNC_ARGS)
 {
 	*colr = *colg = *colb = *cola = 0;
-	*pixel_mode &= ~PMODE;
+	*pixel_mode |= NO_DECO;
 	return 0;
 }
 


### PR DESCRIPTION
This allows WARP particles to remain Invisible and still allow find mode to highlight them in normal view modes (as opposed to just heat view).