### PR TITLE
WOOD Weathering Effect

### DIFF
--- a/src/simulation/elements/WATR.cpp
+++ b/src/simulation/elements/WATR.cpp
@@ -89,6 +89,10 @@ static int update(UPDATE_FUNC_ARGS)
 					else
 						sim->part_change_type(ID(r),x+rx,y+ry,PT_STNE);
 				}
+				else if (TYP(r) == PT_WOOD && parts[ID(r)].tmp < 650 && RNG::Ref().chance(1, 10)) // Wood Weathering  
+				{
+					parts[ID(r)].tmp++;
+				}
 			}
 	return 0;
 }


### PR DESCRIPTION
Simple addition allows WOOD to darken with prolonged contact with WATR. Filed under cool effects that improve the detail of the game. Allows WOOD roofs, underwater structures, etc, to show the effect of being in contact with WATR. 