### PR TITLE
Additional ROCK Reactions

### DIFF
--- a/src/simulation/elements/FIRE.cpp
+++ b/src/simulation/elements/FIRE.cpp
@@ -90,6 +90,17 @@ int Element_FIRE_update(UPDATE_FUNC_ARGS)
 	case PT_LAVA:
 		if (parts[i].ctype == PT_ROCK)
 		{
+			if (parts[i].tmp ==1 && parts[i].temp < 1153.15) //Freezing temp of sulfurized ROCK
+			{
+				sim->part_change_type(i, x, y, PT_ROCK);
+				parts[i].ctype = PT_NONE;
+			}
+			else if (parts[i].temp < 1943.15 && parts[i].tmp != 1) //Freezing temp ROCK
+			{
+				sim->part_change_type(i, x, y, PT_ROCK);
+				parts[i].ctype = PT_NONE;
+			}
+
 			float pres = sim->pv[y / CELL][x / CELL];
 			if (pres <= -9)
 			{

--- a/src/simulation/elements/FIRE.cpp
+++ b/src/simulation/elements/FIRE.cpp
@@ -90,12 +90,12 @@ int Element_FIRE_update(UPDATE_FUNC_ARGS)
 	case PT_LAVA:
 		if (parts[i].ctype == PT_ROCK)
 		{
-			if (parts[i].tmp ==1 && parts[i].temp < 1153.15) //Freezing temp of sulfurized ROCK
+			if (parts[i].tmp == 2 && parts[i].temp < 1153.15) //Freezing temp of sulfurized ROCK
 			{
 				sim->part_change_type(i, x, y, PT_ROCK);
 				parts[i].ctype = PT_NONE;
 			}
-			else if (parts[i].temp < 1943.15 && parts[i].tmp != 1) //Freezing temp ROCK
+			else if (parts[i].temp < 1943.15 && parts[i].tmp != 2) //Freezing temp ROCK
 			{
 				sim->part_change_type(i, x, y, PT_ROCK);
 				parts[i].ctype = PT_NONE;
@@ -255,12 +255,17 @@ int Element_FIRE_update(UPDATE_FUNC_ARGS)
 							parts[ID(r)].ctype = PT_HEAC;
 						}
 					}
-					else if (parts[i].ctype == PT_ROCK && rt == PT_LAVA && parts[ID(r)].ctype == PT_GOLD && parts[ID(r)].tmp == 0 &&
-						sim->pv[y / CELL][x / CELL] >= 50 && RNG::Ref().chance(1, 10000)) // Produce GOLD veins/clusters
+					else if (parts[i].ctype == PT_ROCK)
 					{
-						parts[i].ctype = PT_GOLD;
-						if (rx > 1 || rx < -1) // Trend veins vertical
-							parts[i].tmp = 1;
+						if (parts[i].tmp == 0 && parts[i].temp >= 2000 && parts[ID(r)].temp <= 1875 && RNG::Ref().chance(1, 1000)) // Create sulfurized ROCK when molten rock comes into contact with much colder neighbor
+							parts[i].tmp = 2;
+
+						if (parts[i].ctype == PT_ROCK && rt == PT_LAVA && parts[ID(r)].ctype == PT_GOLD && parts[ID(r)].tmp == 0 && sim->pv[y / CELL][x / CELL] >= 50 && RNG::Ref().chance(1, 10000)) // Produce GOLD veins/clusters
+						{
+							parts[i].ctype = PT_GOLD;
+							if (rx > 1 || rx < -1) // Trend veins vertical
+								parts[i].tmp = 1;
+						}
 					}
 				}
 

--- a/src/simulation/elements/FIRE.cpp
+++ b/src/simulation/elements/FIRE.cpp
@@ -90,7 +90,7 @@ int Element_FIRE_update(UPDATE_FUNC_ARGS)
 	case PT_LAVA:
 		if (parts[i].ctype == PT_ROCK)
 		{
-			if (parts[i].tmp == 2 && parts[i].temp < 1153.15) //Freezing temp of sulfurized ROCK
+			if (parts[i].tmp == 2 && parts[i].temp < 1153.15) //Freezing temp of ROCK State 2 (Reactive)
 			{
 				sim->part_change_type(i, x, y, PT_ROCK);
 				parts[i].ctype = PT_NONE;
@@ -257,7 +257,7 @@ int Element_FIRE_update(UPDATE_FUNC_ARGS)
 					}
 					else if (parts[i].ctype == PT_ROCK)
 					{
-						if (parts[i].tmp == 0 && parts[i].temp >= 2000 && parts[ID(r)].temp <= 1875 && RNG::Ref().chance(1, 1000)) // Create sulfurized ROCK when molten rock comes into contact with much colder neighbor
+						if (parts[i].tmp == 0 && parts[i].temp >= 2000 && parts[ID(r)].temp <= 1875 && RNG::Ref().chance(1, 1000)) // Create ROCK State 2 (Reactive) when molten rock comes into contact with much colder neighbor
 							parts[i].tmp = 2;
 
 						if (parts[i].ctype == PT_ROCK && rt == PT_LAVA && parts[ID(r)].ctype == PT_GOLD && parts[ID(r)].tmp == 0 && sim->pv[y / CELL][x / CELL] >= 50 && RNG::Ref().chance(1, 10000)) // Produce GOLD veins/clusters

--- a/src/simulation/elements/ROCK.cpp
+++ b/src/simulation/elements/ROCK.cpp
@@ -51,7 +51,7 @@ void Element::Element_ROCK()
 
 int Element_ROCK_update(UPDATE_FUNC_ARGS)
 {
-	if (parts[i].tmp == 2 && parts[i].type == PT_ROCK && parts[i].temp >= 873 && RNG::Ref().chance(1, 5000)) //Sulfurized ROCK Heat Reactions
+	if (parts[i].tmp == 2 && parts[i].type == PT_ROCK && parts[i].temp >= 873 && RNG::Ref().chance(1, 5000)) //ROCK State 2 (Reactive) Heat Reactions
 	{
 		if (RNG::Ref().chance(1, 15))
 		{
@@ -74,7 +74,7 @@ int Element_ROCK_update(UPDATE_FUNC_ARGS)
 		sim->part_change_type(i, x, y, PT_LAVA);
 		parts[i].ctype = PT_ROCK;
 	}
-	else if (parts[i].type == PT_ROCK && parts[i].temp >= 1153.15 && parts[i].tmp == 2) //Sulfurized ROCK, Lower Melting Temp
+	else if (parts[i].type == PT_ROCK && parts[i].temp >= 1153.15 && parts[i].tmp == 2) //ROCK State 2 (Reactive), Lower Melting Temp
 	{
 		parts[i].ctype = PT_ROCK;
 		sim->part_change_type(i, x, y, PT_LAVA);
@@ -99,7 +99,7 @@ static int graphics(GRAPHICS_FUNC_ARGS)
 		*fireg = *colg;
 		*fireb = *colb;
 	}
-	if (cpart->tmp == 2) //Yellow Color Shift (Sulfurized ROCK Reactions)
+	if (cpart->tmp == 2) //Yellow Color Shift (ROCK State 2 (Reactive) Reactions)
 	{
 		*colr += 50;
 		*colg += 30;

--- a/src/simulation/elements/ROCK.cpp
+++ b/src/simulation/elements/ROCK.cpp
@@ -51,13 +51,43 @@ void Element::Element_ROCK()
 
 int Element_ROCK_update(UPDATE_FUNC_ARGS)
 {
+
+	int r, rx, ry;
+	for (rx = -2; rx < 3; rx++)
+		for (ry = -2; ry < 3; ry++)
+			if (BOUNDS_CHECK && (rx || ry))
+			{
+				r = pmap[y + ry][x + rx];
+				if (!r)
+					continue;
+				if ((TYP(r) == PT_WATR || TYP(r) == PT_WTRV) && parts[ID(r)].tmp == 1 && parts[i].tmp != 2) //WATR and WTRV Reactions
+				{
+					if (RNG::Ref().chance(1, 5000))
+					{
+						sim->part_change_type(i, x, y, PT_GOLD);
+						parts[ID(r)].tmp = 0;
+					}
+					else if (RNG::Ref().chance(1, 1000))
+					{
+						sim->part_change_type(i, x, y, PT_QRTZ);
+						parts[ID(r)].tmp = 0;
+					}
+					else if (RNG::Ref().chance(1, 500))
+					{
+						parts[i].tmp = 2; //Set to ROCK State 2 (Reactive)
+						parts[ID(r)].tmp = 0;
+					}
+				}
+			}
+
+
+
 	if (parts[i].tmp == 2 && parts[i].type == PT_ROCK && parts[i].temp >= 873 && RNG::Ref().chance(1, 5000)) //ROCK State 2 (Reactive) Heat Reactions
 	{
-		if (RNG::Ref().chance(1, 15))
-		{
+		if (RNG::Ref().chance(1, 50))
 			sim->create_part(-1, x + RNG::Ref().chance(1, 3) - 2, y + RNG::Ref().chance(1, 3) - 2, PT_CAUS);
-		}
-		sim->create_part(-1, x + RNG::Ref().chance(1, 3) - 2, y + RNG::Ref().chance(1, 3) - 2, PT_SMKE);
+		else if (RNG::Ref().chance(1, 15))
+			sim->create_part(-1, x + RNG::Ref().chance(1, 3) - 2, y + RNG::Ref().chance(1, 3) - 2, PT_SMKE);
 
 		if (RNG::Ref().chance(1, 250))
 			sim->part_change_type(i, x, y, PT_METL);

--- a/src/simulation/elements/ROCK.cpp
+++ b/src/simulation/elements/ROCK.cpp
@@ -51,12 +51,7 @@ void Element::Element_ROCK()
 
 int Element_ROCK_update(UPDATE_FUNC_ARGS)
 {
-	int rx, ry;
-	parts[i].pavg[0] = parts[i].pavg[1];
-	parts[i].pavg[1] = sim->pv[y / CELL][x / CELL];
-	float diff = parts[i].pavg[1] - parts[i].pavg[0];
-	
-	if (parts[i].tmp == 1 && parts[i].type == PT_ROCK && parts[i].temp >= 873 && RNG::Ref().chance(1, 5000)) //Sulfurized ROCK Heat Reactions
+	if (parts[i].tmp == 2 && parts[i].type == PT_ROCK && parts[i].temp >= 873 && RNG::Ref().chance(1, 5000)) //Sulfurized ROCK Heat Reactions
 	{
 		if (RNG::Ref().chance(1, 15))
 		{
@@ -74,12 +69,12 @@ int Element_ROCK_update(UPDATE_FUNC_ARGS)
 
 
 	/*SPECIAL HIGH TEMP TRANSITIONS*/
-	if (parts[i].type == PT_ROCK && parts[i].temp >= 1943.15 && parts[i].tmp == 0) //ROCK
+	if (parts[i].type == PT_ROCK && parts[i].temp >= 1943.15 && parts[i].tmp != 2) //ROCK
 	{
 		sim->part_change_type(i, x, y, PT_LAVA);
 		parts[i].ctype = PT_ROCK;
 	}
-	else if (parts[i].type == PT_ROCK && parts[i].temp >= 1153.15 && parts[i].tmp == 1) //Sulfurized ROCK, Lower Melting Temp
+	else if (parts[i].type == PT_ROCK && parts[i].temp >= 1153.15 && parts[i].tmp == 2) //Sulfurized ROCK, Lower Melting Temp
 	{
 		parts[i].ctype = PT_ROCK;
 		sim->part_change_type(i, x, y, PT_LAVA);
@@ -104,7 +99,7 @@ static int graphics(GRAPHICS_FUNC_ARGS)
 		*fireg = *colg;
 		*fireb = *colb;
 	}
-	if (cpart->tmp == 1) //Yellow Color Shift (Sulfurized ROCK Reactions)
+	if (cpart->tmp == 2) //Yellow Color Shift (Sulfurized ROCK Reactions)
 	{
 		*colr += 50;
 		*colg += 30;

--- a/src/simulation/elements/WATR.cpp
+++ b/src/simulation/elements/WATR.cpp
@@ -89,6 +89,8 @@ static int update(UPDATE_FUNC_ARGS)
 					else
 						sim->part_change_type(ID(r),x+rx,y+ry,PT_STNE);
 				}
+				else if (TYP(r) == PT_LAVA && (parts[ID(r)].ctype == PT_STNE || parts[ID(r)].ctype == PT_NONE || parts[ID(r)].ctype == PT_ROCK)) //For ROCK Reaction, "picks up" random valuable element from LAVA to deposit when in contact with ROCK
+					parts[i].tmp = 1;
 			}
 	return 0;
 }

--- a/src/simulation/elements/WTRV.cpp
+++ b/src/simulation/elements/WTRV.cpp
@@ -62,6 +62,8 @@ static int update(UPDATE_FUNC_ARGS)
 					parts[i].life = 4;
 					parts[i].ctype = PT_WATR;
 				}
+				if (TYP(r) == PT_LAVA && (parts[ID(r)].ctype == PT_STNE || parts[ID(r)].ctype == PT_NONE || parts[ID(r)].ctype == PT_ROCK)) //For ROCK Reaction, "picks up" random valuable element from LAVA to deposit when in contact with ROCK
+					parts[i].tmp = 1;
 			}
 	if(parts[i].temp>1273&&parts[i].ctype==PT_FIRE)
 		parts[i].temp-=parts[i].temp/1000;


### PR DESCRIPTION
Adds new path to create CAUS, MERC, GOLD, SMKE, METL, and QRTZ. Adds a reactive form of ROCK. 

Setting TMP1 to 2 makes ROCK more reactive and lowers the melting temperature. This mimics sulfide rocks ITRW, but allows more more elements to be created from ROCK. These more reactive particles of ROCK are seen by a yellow shift in the graphics function. Lower melting temperature of the more reactive particles allows them to be separated and used by players (think of factory saves that create METL, GOLD, or even CAUS, etc). Lower melting temperature will also allow players to create more interesting landscapes. Low on the list, it will also provide an additional 10 particle colors for use on non-deco saves. 

WATR or WTRV in contact with LAVA can deposit other elements into ROCK. Currently, QRTZ, GOLD, and can change ROCK to it's reactive form which in turn allows for METL, MERC, GOLD, CAUS, and SMKE.

MERC, GOLD, METL, and QRTZ synthesis from other particles is lacking in the game, this provides a path for all.