### PR TITLE
Upgrade C++ Standard into C++17

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.8'
+          python-version: '3.10'
       - id: get_type
         run: python3 ./.github/get-type.py ${{ github.ref }}
       - id: create_release
@@ -96,7 +96,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.8'
+          python-version: '3.10'
       - id: get_type
         run: python3 ./.github/get-type.py ${{ github.ref }}
       - if: matrix.platform_short == 'mac'
@@ -171,7 +171,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.8'
+          python-version: '3.10'
       - id: get_type
         run: python3 ./.github/get-type.py ${{ github.ref }}
       - uses: actions/download-artifact@v1
@@ -193,7 +193,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.8'
+          python-version: '3.10'
       - id: get_type
         run: python3 ./.github/get-type.py ${{ github.ref }}
       - run: ./.github/starcatcher-release.sh "https://starcatcher.us/TPT/perform-release.lua?mod=${{ steps.get_type.outputs.MOD_ID }}&type=${{ steps.get_type.outputs.TYPE }}&name=${{ steps.get_type.outputs.NAME }}&commit=${{ github.sha }}"

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('the-powder-toy', [ 'c', 'cpp' ], version: 'the.cake.is.a.lie', default_options: [
-	'cpp_std=c++11',
+	'cpp_std=c++17',
 ])
 
 to_array = generator(

--- a/src/client/http/RequestMonitor.h
+++ b/src/client/http/RequestMonitor.h
@@ -47,7 +47,7 @@ namespace http
 			request->Start();
 		}
 
-		virtual void OnResponse(typename std::result_of<decltype(&R::Finish)(R)>::type v) = 0;
+		virtual void OnResponse(typename std::invoke_result<decltype(&R::Finish), R>::type v) = 0;
 	};
 }
 

--- a/src/common/tpt-compat.h
+++ b/src/common/tpt-compat.h
@@ -37,39 +37,4 @@ typedef unsigned short Uint16;
 # define NULL 0
 #endif
 
-// From https://stackoverflow.com/questions/17902405/how-to-implement-make-unique-function-in-c11
-
-#if !(__cplusplus >= 201402L || defined(_MSC_VER))
-namespace std {
-    template<class T> struct _Unique_if {
-        typedef unique_ptr<T> _Single_object;
-    };
-
-    template<class T> struct _Unique_if<T[]> {
-        typedef unique_ptr<T[]> _Unknown_bound;
-    };
-
-    template<class T, size_t N> struct _Unique_if<T[N]> {
-        typedef void _Known_bound;
-    };
-
-    template<class T, class... Args>
-        typename _Unique_if<T>::_Single_object
-        make_unique(Args&&... args) {
-            return unique_ptr<T>(new T(std::forward<Args>(args)...));
-        }
-
-    template<class T>
-        typename _Unique_if<T>::_Unknown_bound
-        make_unique(size_t n) {
-            typedef typename remove_extent<T>::type U;
-            return unique_ptr<T>(new U[n]());
-        }
-
-    template<class T, class... Args>
-        typename _Unique_if<T>::_Known_bound
-        make_unique(Args&&...) = delete;
-}
-#endif
-
 #endif

--- a/src/common/tpt-minmax.h
+++ b/src/common/tpt-minmax.h
@@ -16,27 +16,16 @@
 #ifndef TPT_MINMAX_H
 #define TPT_MINMAX_H
 
+#include <algorithm>
+
 #ifdef _MSC_VER
-// less than VS2013. Untested since I don't use VS2012 anymore
-# if _MSC_VER < 1800
-#  define fmin min
-#  define fminf min
-#  define fmax max
-#  define fmaxf max
-# else
-// >= VS2013
-#  include <algorithm>
-#  define NOMINMAX
-#  ifdef min
-#   undef min
-#  endif
-#  ifdef max
-#   undef max
-#  endif
+# define NOMINMAX
+# ifdef min
+#  undef min
 # endif
-#else
-// not using visual studio, std::min and std::max are normal
-# include <algorithm>
+# ifdef max
+#  undef max
+# endif
 #endif
 
 #endif

--- a/src/gui/font/FontEditor.cpp
+++ b/src/gui/font/FontEditor.cpp
@@ -456,11 +456,11 @@ FontEditor::FontEditor(ByteString target, ByteString source):
 					for(int i = 0; i < tgtFontWidths[p.first]; i++)
 						same = same && tgtFontPixels[p.first][j][i] == srcFontPixels[p.first][j][i];
 			if(!same)
-				std::cout << "U+" << std::hex << p.first << " is present in both files and is different!" << std::endl;
+				std::cout << "U+" << std::hex << (unsigned int)p.first << " is present in both files and is different!" << std::endl;
 		}
 		else
 		{
-			std::cout << "Adding U+" << std::hex << p.first << " to the target" << std::endl;
+			std::cout << "Adding U+" << std::hex << (unsigned int)p.first << " to the target" << std::endl;
 			tgtFontWidths[p.first] = srcFontWidths[p.first];
 			tgtFontPixels[p.first] = p.second;
 		}

--- a/src/gui/game/GameModel.cpp
+++ b/src/gui/game/GameModel.cpp
@@ -20,7 +20,6 @@
 #include "client/SaveFile.h"
 #include "client/SaveInfo.h"
 #include "common/Platform.h"
-#include "common/tpt-compat.h"
 #include "graphics/Renderer.h"
 #include "simulation/Air.h"
 #include "simulation/GOLString.h"

--- a/src/json/jsoncpp.cpp
+++ b/src/json/jsoncpp.cpp
@@ -219,11 +219,7 @@ static int       stackDepth_g = 0;  // see readValue()
 
 namespace Json {
 
-#if __cplusplus >= 201103L
 typedef std::unique_ptr<CharReader> CharReaderPtr;
-#else
-typedef std::auto_ptr<CharReader>   CharReaderPtr;
-#endif
 
 // Implementation of class Features
 // ////////////////////////////////
@@ -3984,11 +3980,7 @@ Value& Path::make(Value& root) const {
 
 namespace Json {
 
-#if __cplusplus >= 201103L
 typedef std::unique_ptr<StreamWriter> StreamWriterPtr;
-#else
-typedef std::auto_ptr<StreamWriter>   StreamWriterPtr;
-#endif
 
 static bool containsControlCharacter(const char* str) {
   while (*str) {

--- a/src/simulation/SimTool.cpp
+++ b/src/simulation/SimTool.cpp
@@ -1,12 +1,12 @@
 #include <cmath>
-#include "simulation/ElementGraphics.h"
-#include "simulation/Gravity.h"
-#include "Misc.h"
-#include "simulation/Simulation.h"
-#include "common/tpt-compat.h"
+
 #include "common/tpt-rand.h"
 #include "graphics/Renderer.h"
+#include "simulation/ElementGraphics.h"
+#include "simulation/Gravity.h"
+#include "simulation/Simulation.h"
 
+#include "Misc.h"
 #include "ToolClasses.h"
 
 SimTool::SimTool():

--- a/src/simulation/SnapshotDelta.cpp
+++ b/src/simulation/SnapshotDelta.cpp
@@ -1,6 +1,5 @@
 #include "SnapshotDelta.h"
 
-#include "common/tpt-compat.h"
 #include "common/tpt-minmax.h"
 
 #include <utility>


### PR DESCRIPTION
[See original pull request](https://github.com/The-Powder-Toy/The-Powder-Toy/pull/810)
The reason why I re-requesting it is because my repository has some error and need to re-open it.

This upgrades C++ standard into C++17(Current C++ standard is C++11).
We can reduce 56 lines of code of it.
(+ also requesting that change Python into latest 3.10)