### PR TITLE
Fix crash on network activity

### DIFF
--- a/src/client/http/Request.cpp
+++ b/src/client/http/Request.cpp
@@ -230,7 +230,6 @@ namespace http
 
 			curl_easy_setopt(easy, CURLOPT_PRIVATE, (void *)this);
 			curl_easy_setopt(easy, CURLOPT_USERAGENT, user_agent.c_str());
-			curl_easy_setopt(easy, CURLOPT_NOSIGNAL, 1L);
 
 			curl_easy_setopt(easy, CURLOPT_WRITEDATA, (void *)this);
 			curl_easy_setopt(easy, CURLOPT_WRITEFUNCTION, Request::WriteDataHandler);


### PR DESCRIPTION
Ignoring broken pipes led to libcurl crashing when connections were dropped, rather than re-attempting. Now, libcurl is not set to ignore broken pipes. Closes #823.