### PR TITLE
Made pavg0 / pavg1 aliases for tmp3 / tmp4 in the Lua API

### DIFF
--- a/src/lua/CommandInterface.cpp
+++ b/src/lua/CommandInterface.cpp
@@ -94,12 +94,12 @@ int CommandInterface::GetPropertyOffset(ByteString key, FormatType & format)
 		offset = offsetof(Particle, dcolour);
 		format = FormatInt;
 	}
-	else if (!key.compare("tmp3"))
+	else if (!key.compare("tmp3") || !key.compare("pavg0"))
 	{
 		offset = offsetof(Particle, tmp3);
 		format = FormatInt;
 	}
-	else if (!key.compare("tmp4"))
+	else if (!key.compare("tmp4") || !key.compare("pavg1"))
 	{
 		offset = offsetof(Particle, tmp4);
 		format = FormatInt;

--- a/src/lua/LuaScriptInterface.cpp
+++ b/src/lua/LuaScriptInterface.cpp
@@ -1109,7 +1109,7 @@ int LuaScriptInterface::simulation_partProperty(lua_State * l)
 		}
 	}
 
-	auto &properties = Particle::GetProperties();
+	auto &properties = Particle::GetProperties(true);
 	auto prop = properties.end();
 
 	//Get field

--- a/src/simulation/Particle.cpp
+++ b/src/simulation/Particle.cpp
@@ -1,8 +1,10 @@
 #include <cstddef>
 #include "Particle.h"
 
-std::vector<StructProperty> const &Particle::GetProperties()
+std::vector<StructProperty> const &Particle::GetProperties(bool includeAliases)
 {
+	static std::vector<StructProperty> propertiesWithAlias;
+	
 	static std::vector<StructProperty> properties = {
 		{ "type"   , StructProperty::ParticleType, (intptr_t)(offsetof(Particle, type   )) },
 		{ "life"   , StructProperty::Integer     , (intptr_t)(offsetof(Particle, life   )) },
@@ -19,5 +21,19 @@ std::vector<StructProperty> const &Particle::GetProperties()
 		{ "tmp4"   , StructProperty::Integer     , (intptr_t)(offsetof(Particle, tmp4   )) },
 		{ "dcolour", StructProperty::UInteger    , (intptr_t)(offsetof(Particle, dcolour)) },
 	};
-	return properties;
+
+	if (propertiesWithAlias.size() == 0)
+	{
+		static std::vector<StructProperty> aliases = {
+			{ "pavg0"  , StructProperty::Integer     , (intptr_t)(offsetof(Particle, tmp3	)) },	
+			{ "pavg1"  , StructProperty::Integer     , (intptr_t)(offsetof(Particle, tmp4	)) },	
+			{ "dcolor" , StructProperty::UInteger    , (intptr_t)(offsetof(Particle, dcolour)) },
+		};
+
+		propertiesWithAlias.reserve(properties.size() + aliases.size());
+		propertiesWithAlias.insert (propertiesWithAlias.end(), properties.begin(), properties.end());
+		propertiesWithAlias.insert (propertiesWithAlias.end(), aliases.begin(), aliases.end());
+	}
+
+	return includeAliases ? propertiesWithAlias : properties;
 }

--- a/src/simulation/Particle.h
+++ b/src/simulation/Particle.h
@@ -19,7 +19,7 @@ struct Particle
 	unsigned int dcolour;
 	/** Returns a list of properties, their type and offset within the structure that can be changed
 	 by higher-level processes referring to them by name such as Lua or the property tool **/
-	static std::vector<StructProperty> const &GetProperties();
+	static std::vector<StructProperty> const &GetProperties(bool includeAliases = false);
 };
 
 #endif


### PR DESCRIPTION
Lua API mehods like `sim.partProperty`, `tpt.get_property` and `tpt.set_property` now treat `pavg0` and `pavg1` as aliases of `tmp3` and `tmp4` in order to keep old Lua scripts from breaking.
Also added `dcolor`, as an alias to `dcolour` that was missing from `sim.partProperty` but already exists in `tpt.get_property` and `tpt.set_property` .