### PR TITLE
Fixed FRAY triggering regardless of SPRK life

### DIFF
--- a/src/simulation/elements/FRAY.cpp
+++ b/src/simulation/elements/FRAY.cpp
@@ -61,7 +61,7 @@ static int update(UPDATE_FUNC_ARGS)
 				r = pmap[y+ry][x+rx];
 				if (!r)
 					continue;
-				if (TYP(r)==PT_SPRK) {
+				if (TYP(r)==PT_SPRK && parts[ID(r)].life == 3) {
 					for (nxx = 0, nyy = 0, nxi = rx*-1, nyi = ry*-1, len = 0; ; nyy+=nyi, nxx+=nxi, len++) {
 						if (!(x+nxi+nxx<XRES && y+nyi+nyy<YRES && x+nxi+nxx >= 0 && y+nyi+nyy >= 0) || len>curlen) {
 							break;


### PR DESCRIPTION
FRAY wasn't checking if SPRK life was 3 when it fires.