### PR TITLE
Make QRTZ slightly change color while growing

### DIFF
--- a/src/simulation/elements/QRTZ.cpp
+++ b/src/simulation/elements/QRTZ.cpp
@@ -104,6 +104,10 @@ int Element_QRTZ_update(UPDATE_FUNC_ARGS)
 						{
 							parts[np].temp = parts[i].temp;
 							parts[np].tmp2 = parts[i].tmp2;
+							if (RNG::Ref().chance(1, 2))
+							{
+								parts[np].tmp2 = std::clamp(parts[np].tmp2 + RNG::Ref().between(-1, 1), 0, 10);
+							}
 							parts[i].tmp--;
 							if (t == PT_PQRT)
 							{


### PR DESCRIPTION
I find the way QRTZ normally grows when exposed to SLTW a bit boring, so I propose that QRTZ slightly change its TMP2 any time it grows to create a more visually interesting effect compared to staying one static color.

Screenshots:

Before modification
![image](https://user-images.githubusercontent.com/59275598/183333182-306cbff3-8b2a-4e41-8634-65fc58c7f7ab.png)

After modification
![image](https://user-images.githubusercontent.com/59275598/183333190-b79527dc-2d48-4700-932d-71de5fcff8cf.png)

Line of modified QRTZ forced to grow
![image](https://user-images.githubusercontent.com/59275598/183333402-d20e0797-d1ce-4248-972f-8bcb70185e88.png)

Line of unmodified QRTZ forced to grow
![image](https://user-images.githubusercontent.com/59275598/183334157-48e681bc-6dab-4460-8635-31fddc71e378.png)

Natural growth through SLTW
![image](https://user-images.githubusercontent.com/59275598/183333841-4f6ce055-2d69-40f2-9239-d5e991b7e344.png)
