### PR TITLE
Make GLAS strengthening reaction more controllable and not so arbitrary

### DIFF
--- a/src/simulation/elements/FIRE.cpp
+++ b/src/simulation/elements/FIRE.cpp
@@ -251,10 +251,9 @@ int Element_FIRE_update(UPDATE_FUNC_ARGS)
 						if (rx > 1 || rx < -1) // Trend veins vertical
 							parts[i].tmp = 1;
 					}
-					else if (parts[i].ctype == PT_SALT && rt == PT_GLAS) 
+					else if (parts[i].ctype == PT_SALT && rt == PT_GLAS && parts[ID(r)].life < 250) 
 					{
-						if (RNG::Ref().chance(1, 100) && parts[ID(r)].life < 15)
-						parts[ID(r)].life += 1;
+						parts[ID(r)].tmp4 += 1;
 					}
 				}
 

--- a/src/simulation/elements/FIRE.cpp
+++ b/src/simulation/elements/FIRE.cpp
@@ -251,9 +251,9 @@ int Element_FIRE_update(UPDATE_FUNC_ARGS)
 						if (rx > 1 || rx < -1) // Trend veins vertical
 							parts[i].tmp = 1;
 					}
-					else if (parts[i].ctype == PT_SALT && rt == PT_GLAS && parts[ID(r)].life < 250) 
+					else if (parts[i].ctype == PT_SALT && rt == PT_GLAS && parts[ID(r)].life < 234 * 120)
 					{
-						parts[ID(r)].tmp4 += 1;
+						parts[ID(r)].life++;
 					}
 				}
 

--- a/src/simulation/elements/FIRE.cpp
+++ b/src/simulation/elements/FIRE.cpp
@@ -253,7 +253,8 @@ int Element_FIRE_update(UPDATE_FUNC_ARGS)
 					}
 					else if (parts[i].ctype == PT_SALT && rt == PT_GLAS) 
 					{
-						parts[ID(r)].life = 10;
+						if (RNG::Ref().chance(1, 100) && parts[ID(r)].life < 15)
+						parts[ID(r)].life += 1;
 					}
 				}
 

--- a/src/simulation/elements/GLAS.cpp
+++ b/src/simulation/elements/GLAS.cpp
@@ -49,31 +49,45 @@ void Element::Element_GLAS()
 
 static int update(UPDATE_FUNC_ARGS)
 {
+	// GLAS strengthening reaction becomes increasingly difficult as it happens, .life increments by 1 every 120, 240 and 360 frames when .life is < 100, >100 but <200 and finally >200 respectively.
+	if (parts[i].life < 100)
+	{
+		if (parts[i].tmp4 >= 120)
+		{
+			parts[i].tmp4 = 0;
+			parts[i].life += 1;
+		}
+	}
+	else if (parts[i].life >= 100 && parts[i].life < 200)
+	{
+		if (parts[i].tmp4 >= 240)
+		{
+			parts[i].tmp4 = 0;
+			parts[i].life += 1;
+		}
+	}
+	else if (parts[i].life >= 200)
+	{
+		if (parts[i].tmp4 >= 360)
+		{
+			parts[i].tmp4 = 0;
+			parts[i].life += 1;
+		}
+	}
+	if (parts[i].life < 16)// Compatibilty stuff
+	{
+		parts[i].life = 16;
+	}
 	auto press = int(sim->pv[y/CELL][x/CELL] * 64);
 	auto diff = press - parts[i].tmp3;
 
-	// Determine whether the GLAS is chemically strengthened via life setting.
-	if (parts[i].life > 0) 
-	{
-		// determined to be strengthened GLAS, increase the pressure by which it shatters
-		// set to 160 because that's a value where the effect is noticable. the 3x increase didn't do much
-		if (diff > 16 * parts[i].life || diff < -16 * parts[i].life) // max = 240, min = 16.
+	// Determine whether the GLAS is chemically strengthened via .life setting. (250 = Max., 16 = Min.)
+		if (diff > parts[i].life || diff < -1*(parts[i].life))
 		{
 			sim->part_change_type(i, x, y, PT_BGLA);
 		}
-	}
-	else 
-	{
-		// regular ol' GLAS
-		if (diff > 16 || diff < -16)
-		{
-			sim->part_change_type(i, x, y, PT_BGLA);
-		}
-	}
-	
 	parts[i].tmp3 = press;
 	return 0;
-	
 }
 
 static void create(ELEMENT_CREATE_FUNC_ARGS)

--- a/src/simulation/elements/GLAS.cpp
+++ b/src/simulation/elements/GLAS.cpp
@@ -57,7 +57,7 @@ static int update(UPDATE_FUNC_ARGS)
 	{
 		// determined to be strengthened GLAS, increase the pressure by which it shatters
 		// set to 160 because that's a value where the effect is noticable. the 3x increase didn't do much
-		if (diff > 160 || diff < -160)
+		if (diff > 16 * parts[i].life || diff < -16 * parts[i].life) // max = 240, min = 16.
 		{
 			sim->part_change_type(i, x, y, PT_BGLA);
 		}

--- a/src/simulation/elements/GLAS.cpp
+++ b/src/simulation/elements/GLAS.cpp
@@ -49,23 +49,17 @@ void Element::Element_GLAS()
 
 static int update(UPDATE_FUNC_ARGS)
 {
-	if (parts[i].tmp4 >= 120) // To make life increments not so random but still way more controllable (1 for every 120 frames).
-	{
-		parts[i].tmp4 = 0;
-		parts[i].life += 1;
-	}
-	if (parts[i].life < 16)// Compatibilty stuff
-	{
-		parts[i].life = 16;
-	}
 	auto press = int(sim->pv[y/CELL][x/CELL] * 64);
 	auto diff = press - parts[i].tmp3;
 
 	// Determine whether the GLAS is chemically strengthened via .life setting. (250 = Max., 16 = Min.)
-		if (diff > parts[i].life || diff < -1*(parts[i].life))
-		{
-			sim->part_change_type(i, x, y, PT_BGLA);
-		}
+	int strength = (parts[i].life / 120) + 16;
+	if (strength < 16)
+		strength = 16;
+	if (diff > strength || diff < -1 * strength)
+	{
+		sim->part_change_type(i, x, y, PT_BGLA);
+	}
 	parts[i].tmp3 = press;
 	return 0;
 }

--- a/src/simulation/elements/GLAS.cpp
+++ b/src/simulation/elements/GLAS.cpp
@@ -49,30 +49,10 @@ void Element::Element_GLAS()
 
 static int update(UPDATE_FUNC_ARGS)
 {
-	// GLAS strengthening reaction becomes increasingly difficult as it happens, .life increments by 1 every 120, 240 and 360 frames when .life is < 100, >100 but <200 and finally >200 respectively.
-	if (parts[i].life < 100)
+	if (parts[i].tmp4 >= 120) // To make life increments not so random but still way more controllable (1 for every 120 frames).
 	{
-		if (parts[i].tmp4 >= 120)
-		{
-			parts[i].tmp4 = 0;
-			parts[i].life += 1;
-		}
-	}
-	else if (parts[i].life >= 100 && parts[i].life < 200)
-	{
-		if (parts[i].tmp4 >= 240)
-		{
-			parts[i].tmp4 = 0;
-			parts[i].life += 1;
-		}
-	}
-	else if (parts[i].life >= 200)
-	{
-		if (parts[i].tmp4 >= 360)
-		{
-			parts[i].tmp4 = 0;
-			parts[i].life += 1;
-		}
+		parts[i].tmp4 = 0;
+		parts[i].life += 1;
 	}
 	if (parts[i].life < 16)// Compatibilty stuff
 	{


### PR DESCRIPTION
This gives user more control over how much the GLAS can be strengthened by controlling the exposure of molten salt as opposed to an arbitrary value.