### PR TITLE
Fix -no-pie option spelling

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -238,7 +238,11 @@ else
 		if not get_option('b_pie') and get_option('workaround_gcc_no_pie') # nice one, meson
 			if host_arch != 'aarch64' # no position independent executable for aarch64
 				if c_compiler.get_id() in [ 'clang' ]
-					project_link_args += [ '-Wl,-no_pie' ]
+					if host_platform == 'darwin'
+						project_link_args += [ '-Wl,-no_pie' ]
+					else
+						project_link_args += [ '-Wl,-no-pie' ]
+					endif
 				else
 					project_link_args += [ '-no-pie' ]
 				endif


### PR DESCRIPTION
No idea where `-no_pie` comes from, but `lld`, `gold` and `clang` all accept `-no-pie`. For the record, I think that this whole hack should be removed - the commits says it was created for "certain file managers", but shouldn't these file managers be fixed instead, as any installation where executables built with default compiler arguments are not recognized is executables is terminally broken. There's definitely no place for fixes for third party file managers in TPT code.