### PR TITLE
Make file browser respond to search query changes while loading files

### DIFF
--- a/src/gui/filebrowser/FileBrowserActivity.cpp
+++ b/src/gui/filebrowser/FileBrowserActivity.cpp
@@ -83,6 +83,7 @@ FileBrowserActivity::FileBrowserActivity(ByteString directory, OnSelected onSele
 	WindowActivity(ui::Point(-1, -1), ui::Point(500, 350)),
 	onSelected(onSelected_),
 	directory(directory),
+	hasQueuedSearch(false),
 	totalFiles(0)
 {
 
@@ -127,7 +128,12 @@ FileBrowserActivity::FileBrowserActivity(ByteString directory, OnSelected onSele
 
 void FileBrowserActivity::DoSearch(ByteString search)
 {
-	if(!loadFiles)
+	if (loadFiles)
+	{
+		hasQueuedSearch = true;
+		queuedSearch = search;
+	}
+	else
 	{
 		loadDirectory(directory, search);
 	}
@@ -221,6 +227,12 @@ void FileBrowserActivity::NotifyDone(Task * task)
 		delete components[i];
 	}
 	components.clear();
+
+	if (hasQueuedSearch)
+	{
+		hasQueuedSearch = false;
+		loadDirectory(directory, queuedSearch);
+	}
 }
 
 void FileBrowserActivity::OnMouseDown(int x, int y, unsigned button)

--- a/src/gui/filebrowser/FileBrowserActivity.h
+++ b/src/gui/filebrowser/FileBrowserActivity.h
@@ -30,6 +30,8 @@ class FileBrowserActivity: public TaskListener, public WindowActivity
 	std::vector<ui::Component*> components;
 	std::vector<ui::Component*> componentsQueue;
 	ByteString directory;
+	bool hasQueuedSearch;
+	ByteString queuedSearch;
 
 	ui::ProgressBar * progressBar;
 


### PR DESCRIPTION
Suppose you have lots of saves, and you open the local save browser, and it starts iterating through all of them. And you have a really short search query, so you finish typing it before the "loading files" stage finishes. The game will continue loading all the saves, instead of showing you just the saves that match your query.

This solution automatically restarts the loading process after "loading files" is done if the search query was changed in the interim. It doesn't interrupt the file loading process since that would be a little complicated with the current multi-threaded setup, but at least the file browser will show the correct results when it's finally done loading.