### PR TITLE
PHOT revamp

### DIFF
--- a/src/client/GameSave.cpp
+++ b/src/client/GameSave.cpp
@@ -1249,7 +1249,6 @@ void GameSave::readOPS(const std::vector<char> &data)
 							particles[newIndex].tmp = builtinGol[particles[newIndex].ctype].colour2.Pack();
 						}
 					}
-				}
 				case PT_BIZR:
 				case PT_BIZRG:
 				case PT_BIZRS:
@@ -1257,6 +1256,7 @@ void GameSave::readOPS(const std::vector<char> &data)
 					{
 						particles[newIndex].flags |= FLAG_PHOTOLD;
 					}
+				}
 				if (PressureInTmp3(particles[newIndex].type))
 				{
 					// pavg[1] used to be saved as a u16, which PressureInTmp3 elements then treated as

--- a/src/client/GameSave.cpp
+++ b/src/client/GameSave.cpp
@@ -1252,11 +1252,15 @@ void GameSave::readOPS(const std::vector<char> &data)
 				case PT_BIZR:
 				case PT_BIZRG:
 				case PT_BIZRS:
+				case PT_GLAS:
+				case PT_BGLA:
 					if (savedVersion < 99)
 					{
 						particles[newIndex].flags |= FLAG_PHOTOLD;
 					}
 				}
+				if(savedVersion < 99 && elements[particles[newIndex].type].PhotonReflectWavelengths != 0x3FFFFFFF)
+					particles[newIndex].flags |= FLAG_PHOTOLD;
 				if (PressureInTmp3(particles[newIndex].type))
 				{
 					// pavg[1] used to be saved as a u16, which PressureInTmp3 elements then treated as

--- a/src/client/GameSave.cpp
+++ b/src/client/GameSave.cpp
@@ -1175,6 +1175,10 @@ void GameSave::readOPS(const std::vector<char> &data)
 					}
 					break;
 				case PT_PHOT:
+					if (savedVersion < 99)
+					{
+						particles[newIndex].flags |= FLAG_PHOTOLD;
+					}
 					if (savedVersion < 90)
 					{
 						particles[newIndex].flags |= FLAG_PHOTDECO;
@@ -1246,6 +1250,13 @@ void GameSave::readOPS(const std::vector<char> &data)
 						}
 					}
 				}
+				case PT_BIZR:
+				case PT_BIZRG:
+				case PT_BIZRS:
+					if (savedVersion < 99)
+					{
+						particles[newIndex].flags |= FLAG_PHOTOLD;
+					}
 				if (PressureInTmp3(particles[newIndex].type))
 				{
 					// pavg[1] used to be saved as a u16, which PressureInTmp3 elements then treated as

--- a/src/client/GameSave.cpp
+++ b/src/client/GameSave.cpp
@@ -1175,10 +1175,6 @@ void GameSave::readOPS(const std::vector<char> &data)
 					}
 					break;
 				case PT_PHOT:
-					if (savedVersion < 99)
-					{
-						particles[newIndex].flags |= FLAG_PHOTOLD;
-					}
 					if (savedVersion < 90)
 					{
 						particles[newIndex].flags |= FLAG_PHOTDECO;
@@ -1249,17 +1245,8 @@ void GameSave::readOPS(const std::vector<char> &data)
 							particles[newIndex].tmp = builtinGol[particles[newIndex].ctype].colour2.Pack();
 						}
 					}
-				case PT_BIZR:
-				case PT_BIZRG:
-				case PT_BIZRS:
-				case PT_GLAS:
-				case PT_BGLA:
-					if (savedVersion < 99)
-					{
-						particles[newIndex].flags |= FLAG_PHOTOLD;
-					}
 				}
-				if(savedVersion < 99 && elements[particles[newIndex].type].PhotonReflectWavelengths != 0x3FFFFFFF)
+				if(savedVersion < 99)
 					particles[newIndex].flags |= FLAG_PHOTOLD;
 				if (PressureInTmp3(particles[newIndex].type))
 				{

--- a/src/simulation/ElementDefs.h
+++ b/src/simulation/ElementDefs.h
@@ -37,7 +37,7 @@ constexpr auto FLAG_SKIPMOVE      = UINT32_C(0x00000002); // skip movement for o
 //#define FLAG_WATEREQUAL 0x4 //if a liquid was already checked during equalization
 constexpr auto FLAG_MOVABLE       = UINT32_C(0x00000008); // compatibility with old saves (moving SPNG), only applies to SPNG
 constexpr auto FLAG_PHOTDECO      = UINT32_C(0x00000008); // compatibility with old saves (decorated photons), only applies to PHOT. Having the same value as FLAG_MOVABLE is fine because they apply to different elements, and this saves space for future flags,
-
+constexpr auto FLAG_PHOTOLD       = UINT32_C(0x00000010); // compatibility with old saves (old photon reflections and rendering)
 
 #define UPDATE_FUNC_ARGS Simulation* sim, int i, int x, int y, int surround_space, int nt, Particle *parts, int pmap[YRES][XRES]
 #define UPDATE_FUNC_SUBCALL_ARGS sim, i, x, y, surround_space, nt, parts, pmap

--- a/src/simulation/Simulation.cpp
+++ b/src/simulation/Simulation.cpp
@@ -3074,7 +3074,7 @@ killed:
 
 					if (t == PT_PHOT)
 					{
-						unsigned int mask = 0;
+						unsigned int mask = 0x3FFFFFFF;
 						if(parts[i].flags & FLAG_PHOTOLD)
 							mask = elements[TYP(r)].PhotonReflectWavelengths;
 						else if (TYP(r) != PT_LITH)
@@ -3103,9 +3103,9 @@ killed:
 								int dr = (parts[ID(r)].dcolour>>16)&0xFF;
 								int dg = (parts[ID(r)].dcolour>>8)&0xFF;
 								int db = (parts[ID(r)].dcolour)&0xFF;
-								cr = (da*dr + (256-da)*cr) >> 8;
-								cg = (da*dg + (256-da)*cg) >> 8;
-								cb = (da*db + (256-da)*cb) >> 8;
+								cr = (da*dr + (255-da)*cr) / 255;
+								cg = (da*dg + (255-da)*cg) / 255;
+								cb = (da*db + (255-da)*cb) / 255;
 							}
 							float vl = std::max({cr, cg, cb});
 							if (vl == 0.0f)
@@ -3113,7 +3113,7 @@ killed:
 								kill_part(i);
 								continue;
 							}
-							parts[i].ctype &= colourToWavelength(cr, cg, cb);
+							mask = colourToWavelength(cr, cg, cb);
 							if (parts[i].life > 0)
 							{
 								parts[i].life /= (255 / vl);

--- a/src/simulation/Simulation.cpp
+++ b/src/simulation/Simulation.cpp
@@ -3000,7 +3000,7 @@ killed:
 						int lt_glas = (lt == PT_GLAS) || (lt == PT_BGLA);
 						if(!(parts[i].flags & FLAG_PHOTOLD))
 						{
-							if(rt_glas)
+							if(rt_glas && !(parts[ID(pmap[fin_y][fin_x])].flags & FLAG_PHOTOLD))
 							{
 								int glasdeco = parts[ID(pmap[fin_y][fin_x])].dcolour;
 								if(glasdeco)
@@ -3009,7 +3009,7 @@ killed:
 									parts[i].ctype &= colourToWavelength(dr, dg, db);
 								}
 							}
-							if(lt_glas)
+							if(lt_glas && !(parts[ID(pmap[y][x])].flags & FLAG_PHOTOLD))
 							{
 								int glasdeco = parts[ID(pmap[y][x])].dcolour;
 								if(glasdeco)

--- a/src/simulation/Simulation.cpp
+++ b/src/simulation/Simulation.cpp
@@ -3107,22 +3107,16 @@ killed:
 								cg = (da*dg + (255-da)*cg) / 255;
 								cb = (da*db + (255-da)*cb) / 255;
 							}
-							float vl = std::max({cr, cg, cb});
-							if (vl == 0.0f)
-							{
-								kill_part(i);
-								continue;
-							}
-							mask = colourToWavelength(cr, cg, cb);
 							if (parts[i].life > 0)
 							{
-								parts[i].life /= (255 / vl);
+								parts[i].life = parts[i].life * std::max({cr, cg, cb}) / 255;
 								if (parts[i].life < 2)
 								{
 									kill_part(i);
 									continue;
 								}
 							}
+							mask = colourToWavelength(cr, cg, cb);
 						}
 						else if (TYP(r) == PT_LITH)
 						{

--- a/src/simulation/Simulation.cpp
+++ b/src/simulation/Simulation.cpp
@@ -3096,7 +3096,7 @@ killed:
 					if (t == PT_PHOT)
 					{
 						unsigned int mask = 0x3FFFFFFF;
-						if(parts[i].flags & FLAG_PHOTOLD)
+						if((parts[i].flags | parts[ID(r)].flags) & FLAG_PHOTOLD)
 							mask = elements[TYP(r)].PhotonReflectWavelengths;
 						else if (TYP(r) != PT_LITH)
 						{

--- a/src/simulation/Simulation.cpp
+++ b/src/simulation/Simulation.cpp
@@ -3088,7 +3088,7 @@ killed:
 							}
 							else if (TYP(r) == PT_BRAY || TYP(r) == PT_BIZR || TYP(r) == PT_BIZRG || TYP(r) == PT_BIZRS)
 							{
-								RGB<uint8_t> tempcolor = wavelengthToColour(cpart->ctype);
+								RGB<uint8_t> tempcolor = wavelengthToColour(parts[ID(r)].ctype);
 								cr = tempcolor.Red, cg = tempcolor.Green, cb = tempcolor.Blue;
 							}
 							else

--- a/src/simulation/Simulation.cpp
+++ b/src/simulation/Simulation.cpp
@@ -2998,6 +2998,27 @@ killed:
 						int lt = TYP(pmap[y][x]);
 						int rt_glas = (rt == PT_GLAS) || (rt == PT_BGLA);
 						int lt_glas = (lt == PT_GLAS) || (lt == PT_BGLA);
+						if(!(parts[i].flags & FLAG_PHOTOLD))
+						{
+							if(rt_glas)
+							{
+								int glasdeco = parts[ID(pmap[fin_y][fin_x])].dcolour;
+								if(glasdeco)
+								{
+									int dr = (glasdeco>>16)&0xFF, dg = (glasdeco>>8)&0xFF, db = glasdeco&0xFF;
+									parts[i].ctype &= colourToWavelength(dr, dg, db);
+								}
+							}
+							if(lt_glas)
+							{
+								int glasdeco = parts[ID(pmap[y][x])].dcolour;
+								if(glasdeco)
+								{
+									int dr = (glasdeco>>16)&0xFF, dg = (glasdeco>>8)&0xFF, db = glasdeco&0xFF;
+									parts[i].ctype &= colourToWavelength(dr, dg, db);
+								}
+							}
+						}
 						if ((rt_glas && !lt_glas) || (lt_glas && !rt_glas))
 						{
 							auto gn = get_normal_interp<true>(*this, REFRACT|t, parts[i].x, parts[i].y, parts[i].vx, parts[i].vy);

--- a/src/simulation/SimulationData.cpp
+++ b/src/simulation/SimulationData.cpp
@@ -214,11 +214,11 @@ void SimulationData::init_can_move()
 	can_move[PT_PHOT][PT_LCRY] = 3; //varies according to LCRY life
 	can_move[PT_PHOT][PT_GPMP] = 3;
 
-	can_move[PT_PHOT][PT_BIZR] = 2;
+	can_move[PT_PHOT][PT_BIZR] = 3;
 	can_move[PT_ELEC][PT_BIZR] = 2;
-	can_move[PT_PHOT][PT_BIZRG] = 2;
+	can_move[PT_PHOT][PT_BIZRG] = 3;
 	can_move[PT_ELEC][PT_BIZRG] = 2;
-	can_move[PT_PHOT][PT_BIZRS] = 2;
+	can_move[PT_PHOT][PT_BIZRS] = 3;
 	can_move[PT_ELEC][PT_BIZRS] = 2;
 	can_move[PT_BIZR][PT_FILT] = 2;
 	can_move[PT_BIZRG][PT_FILT] = 2;

--- a/src/simulation/elements/BIZR.cpp
+++ b/src/simulation/elements/BIZR.cpp
@@ -95,19 +95,8 @@ int Element_BIZR_graphics(GRAPHICS_FUNC_ARGS)
 	float brightness = fabs(cpart->vx) + fabs(cpart->vy);
 	if (cpart->ctype&0x3FFFFFFF)
 	{
-		*colg = 0;
-		*colb = 0;
-		*colr = 0;
-		for (x=0; x<12; x++) {
-			*colr += (cpart->ctype >> (x+18)) & 1;
-			*colb += (cpart->ctype >>  x)     & 1;
-		}
-		for (x=0; x<12; x++)
-			*colg += (cpart->ctype >> (x+9))  & 1;
-		x = 624 / (*colr + *colg + *colb + 1);
-		*colr *= x;
-		*colg *= x;
-		*colb *= x;
+		RGB<uint8_t> tempcolor = wavelengthToColour(cpart->ctype);
+		*colr = tempcolor.Red, *colg = tempcolor.Green, *colb = tempcolor.Blue;
 	}
 
 	if(brightness>0)

--- a/src/simulation/elements/BIZR.cpp
+++ b/src/simulation/elements/BIZR.cpp
@@ -1,5 +1,6 @@
 #include "simulation/ElementCommon.h"
 #include "BIZR.h"
+#include "FILT.h"
 
 void Element::Element_BIZR()
 {
@@ -91,7 +92,6 @@ int Element_BIZR_update(UPDATE_FUNC_ARGS)
 int Element_BIZR_graphics(GRAPHICS_FUNC_ARGS)
  //BIZR, BIZRG, BIZRS
 {
-	int x = 0;
 	float brightness = fabs(cpart->vx) + fabs(cpart->vy);
 	if (cpart->ctype&0x3FFFFFFF)
 	{

--- a/src/simulation/elements/BRAY.cpp
+++ b/src/simulation/elements/BRAY.cpp
@@ -55,19 +55,8 @@ static int graphics(GRAPHICS_FUNC_ARGS)
 		trans = cpart->life * 7;
 		if (trans>255) trans = 255;
 		if (cpart->ctype&0x3FFFFFFF) {
-			*colg = 0;
-			*colb = 0;
-			*colr = 0;
-			for (x=0; x<12; x++) {
-				*colr += (cpart->ctype >> (x+18)) & 1;
-				*colb += (cpart->ctype >>  x)	 & 1;
-			}
-			for (x=0; x<12; x++)
-				*colg += (cpart->ctype >> (x+9))  & 1;
-			x = 624/(*colr+*colg+*colb+1);
-			*colr *= x;
-			*colg *= x;
-			*colb *= x;
+			RGB<uint8_t> tempcolor = wavelengthToColour(cpart->ctype);
+			*colr = tempcolor.Red, *colg = tempcolor.Green, *colb = tempcolor.Blue;
 		}
 	}
 	else if(cpart->tmp==1)
@@ -75,19 +64,8 @@ static int graphics(GRAPHICS_FUNC_ARGS)
 		trans = cpart->life/4;
 		if (trans>255) trans = 255;
 		if (cpart->ctype&0x3FFFFFFF) {
-			*colg = 0;
-			*colb = 0;
-			*colr = 0;
-			for (x=0; x<12; x++) {
-				*colr += (cpart->ctype >> (x+18)) & 1;
-				*colb += (cpart->ctype >>  x)	 & 1;
-			}
-			for (x=0; x<12; x++)
-				*colg += (cpart->ctype >> (x+9))  & 1;
-			x = 624/(*colr+*colg+*colb+1);
-			*colr *= x;
-			*colg *= x;
-			*colb *= x;
+			RGB<uint8_t> tempcolor = wavelengthToColour(cpart->ctype);
+			*colr = tempcolor.Red, *colg = tempcolor.Green, *colb = tempcolor.Blue;
 		}
 	}
 	else if(cpart->tmp==2)

--- a/src/simulation/elements/BRAY.cpp
+++ b/src/simulation/elements/BRAY.cpp
@@ -1,4 +1,5 @@
 #include "simulation/ElementCommon.h"
+#include "FILT.h"
 
 static int graphics(GRAPHICS_FUNC_ARGS);
 

--- a/src/simulation/elements/BRAY.cpp
+++ b/src/simulation/elements/BRAY.cpp
@@ -50,7 +50,7 @@ void Element::Element_BRAY()
 
 static int graphics(GRAPHICS_FUNC_ARGS)
 {
-	int x, trans = 255;
+	int trans = 255;
 	if(cpart->tmp==0)
 	{
 		trans = cpart->life * 7;

--- a/src/simulation/elements/CRAY.cpp
+++ b/src/simulation/elements/CRAY.cpp
@@ -117,7 +117,7 @@ static int update(UPDATE_FUNC_ARGS)
 								else if (parts[ID(r)].tmp==0)
 								{
 									RGB<uint8_t> tempcolor = wavelengthToColour(Element_FILT_getWavelengths(&parts[ID(r)]));
-									colored = tempcolor.Red << 16 + tempcolor.Green << 8 + tempcolor.Blue;
+									colored = 0xFF000000 + (int)(tempcolor.Red) << 16 + (int)(tempcolor.Green) << 8 + (int)(tempcolor.Blue);
 								}
 								else if (colored==0xFF000000)
 									colored = 0;

--- a/src/simulation/elements/CRAY.cpp
+++ b/src/simulation/elements/CRAY.cpp
@@ -3,7 +3,6 @@
 
 static int update(UPDATE_FUNC_ARGS);
 static bool ctypeDraw(CTYPEDRAW_FUNC_ARGS);
-static unsigned int wavelengthToDecoColour(int wavelength);
 
 void Element::Element_CRAY()
 {
@@ -117,7 +116,8 @@ static int update(UPDATE_FUNC_ARGS)
 									colored = 0xFF000000;
 								else if (parts[ID(r)].tmp==0)
 								{
-									colored = wavelengthToDecoColour(Element_FILT_getWavelengths(&parts[ID(r)]));
+									RGB<uint8_t> tempcolor = wavelengthToColour(Element_FILT_getWavelengths(&parts[ID(r)]));
+									colored = tempcolor.Red << 16 + tempcolor.Green << 8 + tempcolor.Blue;
 								}
 								else if (colored==0xFF000000)
 									colored = 0;
@@ -140,30 +140,6 @@ static int update(UPDATE_FUNC_ARGS)
 		}
 	}
 	return 0;
-}
-
-static unsigned int wavelengthToDecoColour(int wavelength)
-{
-	int colr = 0, colg = 0, colb = 0, x;
-	for (x=0; x<12; x++) {
-		colr += (wavelength >> (x+18)) & 1;
-		colb += (wavelength >>  x)     & 1;
-	}
-	for (x=0; x<12; x++)
-		colg += (wavelength >> (x+9))  & 1;
-	x = 624/(colr+colg+colb+1);
-	colr *= x;
-	colg *= x;
-	colb *= x;
-
-	if(colr > 255) colr = 255;
-	else if(colr < 0) colr = 0;
-	if(colg > 255) colg = 255;
-	else if(colg < 0) colg = 0;
-	if(colb > 255) colb = 255;
-	else if(colb < 0) colb = 0;
-
-	return (255<<24) | (colr<<16) | (colg<<8) | colb;
 }
 
 static bool ctypeDraw(CTYPEDRAW_FUNC_ARGS)

--- a/src/simulation/elements/CRAY.cpp
+++ b/src/simulation/elements/CRAY.cpp
@@ -117,7 +117,7 @@ static int update(UPDATE_FUNC_ARGS)
 								else if (parts[ID(r)].tmp==0)
 								{
 									RGB<uint8_t> tempcolor = wavelengthToColour(Element_FILT_getWavelengths(&parts[ID(r)]));
-									colored = 0xFF000000 + (int)(tempcolor.Red) << 16 + (int)(tempcolor.Green) << 8 + (int)(tempcolor.Blue);
+									colored = 0xFF000000 | (int)(tempcolor.Red) << 16 | (int)(tempcolor.Green) << 8 | (int)(tempcolor.Blue);
 								}
 								else if (colored==0xFF000000)
 									colored = 0;

--- a/src/simulation/elements/FILT.cpp
+++ b/src/simulation/elements/FILT.cpp
@@ -180,7 +180,7 @@ int colourToWavelength(int cr, int cg, int cb)
 	int shg = 0;
 	if (vg > 6)
 	{
-		shg = std::max(std::min({vr - vb, vg - 6, 3}), 6 - vg, -3);
+		shg = std::max({std::min({vr - vb, vg - 6, 3}), 6 - vg, -3});
 		vr -= std::max(shg, 0);
 		vb += std::min(shg, 0);
 	}

--- a/src/simulation/elements/FILT.cpp
+++ b/src/simulation/elements/FILT.cpp
@@ -201,11 +201,11 @@ RGB<uint8_t> wavelengthToColour(int wavelength)
 {
 	int x, colr, colg, colb;
 	for (colr = colg = colb = x = 0; x<12; x++) {
-		*colr += (wavelength >> (x+18)) & 1;
-		*colg += (wavelength >> (x+9))  & 1;
-		*colb += (wavelength >>  x)	    & 1;
+		colr += (wavelength >> (x+18)) & 1;
+		colg += (wavelength >> (x+9))  & 1;
+		colb += (wavelength >>  x)	    & 1;
 	}
-	double xl = 255.0 / std::max(std::max(*colr,*colg),*colb);
+	double xl = 255.0 / std::max({colr,colg,colb});
 	colr *= xl;
 	colg *= xl;
 	colb *= xl;

--- a/src/simulation/elements/FILT.cpp
+++ b/src/simulation/elements/FILT.cpp
@@ -50,24 +50,14 @@ void Element::Element_FILT()
 
 static int graphics(GRAPHICS_FUNC_ARGS)
 {
-	int x, wl = Element_FILT_getWavelengths(cpart);
-	*colg = 0;
-	*colb = 0;
-	*colr = 0;
-	for (x=0; x<12; x++) {
-		*colr += (wl >> (x+18)) & 1;
-		*colb += (wl >>  x)     & 1;
-	}
-	for (x=0; x<12; x++)
-		*colg += (wl >> (x+9))  & 1;
-	x = 624/(*colr+*colg+*colb+1);
+	int wl = Element_FILT_getWavelengths(cpart);
+	RGB<uint8_t> tempcolor = wavelengthToColour(wl);
+	*colr = tempcolor.Red, *colg = tempcolor.Green, *colb = tempcolor.Blue;
+	
 	if (cpart->life>0 && cpart->life<=4)
 		*cola = 127+cpart->life*30;
 	else
 		*cola = 127;
-	*colr *= x;
-	*colg *= x;
-	*colb *= x;
 	*pixel_mode &= ~PMODE;
 	*pixel_mode |= PMODE_BLEND;
 	return 0;
@@ -203,7 +193,7 @@ RGB<uint8_t> wavelengthToColour(int wavelength)
 	for (colr = colg = colb = x = 0; x<12; x++) {
 		colr += (wavelength >> (x+18)) & 1;
 		colg += (wavelength >> (x+9))  & 1;
-		colb += (wavelength >>  x)	    & 1;
+		colb += (wavelength >>  x)	   & 1;
 	}
 	double xl = 255.0 / std::max({colr,colg,colb});
 	colr *= xl;

--- a/src/simulation/elements/FILT.h
+++ b/src/simulation/elements/FILT.h
@@ -3,3 +3,5 @@
 
 int Element_FILT_getWavelengths(const Particle* cpart);
 int Element_FILT_interactWavelengths(Simulation *sim, Particle* cpart, int origWl);
+int colourToWavelength(int cr, int cg, int cb)
+RGB<uint8_t> wavelengthToColour(int wavelength)

--- a/src/simulation/elements/FILT.h
+++ b/src/simulation/elements/FILT.h
@@ -3,5 +3,5 @@
 
 int Element_FILT_getWavelengths(const Particle* cpart);
 int Element_FILT_interactWavelengths(Simulation *sim, Particle* cpart, int origWl);
-int colourToWavelength(int cr, int cg, int cb)
-RGB<uint8_t> wavelengthToColour(int wavelength)
+int colourToWavelength(int cr, int cg, int cb);
+RGB<uint8_t> wavelengthToColour(int wavelength);

--- a/src/simulation/elements/PHOT.cpp
+++ b/src/simulation/elements/PHOT.cpp
@@ -146,23 +146,13 @@ static int update(UPDATE_FUNC_ARGS)
 
 static int graphics(GRAPHICS_FUNC_ARGS)
 {
-	int x = 0;
-	*colr = *colg = *colb = 0;
-	for (x=0; x<12; x++) {
-		*colr += (cpart->ctype >> (x+18)) & 1;
-		*colb += (cpart->ctype >>  x)     & 1;
-	}
-	for (x=0; x<12; x++)
-		*colg += (cpart->ctype >> (x+9))  & 1;
-	x = 624/(*colr+*colg+*colb+1);
-	*colr *= x;
-	*colg *= x;
-	*colb *= x;
-
-	*firea = 100;
-	*firer = *colr;
-	*fireg = *colg;
-	*fireb = *colb;
+	double lm = std::min(cpart->life, 680) / 680.0;
+	if (cpart->life <= 0 || FLAG_PHOTOLD)
+		lm = 1.0;
+	RGB<uint8_t> tempcolor = wavelengthToColour(cpart->ctype);
+	*firer = *colr = tempcolor.Red, *fireg = *colg = tempcolor.Green, *fireb = *colb = tempcolor.Blue;
+	*firea = round(100.0 * lm);
+	*cola = round(255.0 * lm);
 
 	*pixel_mode &= ~PMODE_FLAT;
 	*pixel_mode |= FIRE_ADD | PMODE_ADD | NO_DECO;

--- a/src/simulation/elements/PHOT.cpp
+++ b/src/simulation/elements/PHOT.cpp
@@ -147,7 +147,7 @@ static int update(UPDATE_FUNC_ARGS)
 static int graphics(GRAPHICS_FUNC_ARGS)
 {
 	double lm = std::min(cpart->life, 680) / 680.0;
-	if (cpart->life <= 0 || FLAG_PHOTOLD)
+	if (cpart->life <= 0 || (cpart->flags & FLAG_PHOTOLD))
 		lm = 1.0;
 	RGB<uint8_t> tempcolor = wavelengthToColour(cpart->ctype);
 	*firer = *colr = tempcolor.Red, *fireg = *colg = tempcolor.Green, *fireb = *colb = tempcolor.Blue;


### PR DESCRIPTION
- [x] Set PHOT brightness according to its life
- [x] Make PHOT change wavelength upon reflecting from most particles
- [x] Make dcolour affect reflected wavelength
- [x] Implement ability to change PHOT ctype using its dcolour value (deco tool)
- [x] Add stained GLAS/BGLA support
- [x] Make SPRK and decorated BIZR/G/S reflectable
- [x] Get SPRK reflection from its ctype
- [x] Get BIZR/G/S and BRAY reflection from their wavelength
- [x] Fix wavelength <-> color operations having not enough precision
- [x] Make all (or at least most) wavelength<->color operations use the same functions
- [x] Backwards compatibility
- [x] Resolve conflicts
- (Optional) Move the wavelength shared functions outside of FILT.h (I don't know where they should be exactly)
- (Optional) Make the backwards compatibility not involve setting the flags (perhaps some simulation setting)