### PR TITLE
resources/meson.build: fix condition for most POSIX OSes

### DIFF
--- a/resources/meson.build
+++ b/resources/meson.build
@@ -68,7 +68,7 @@ elif host_platform == 'darwin'
 		output: 'Info.plist',
 		configuration: conf_data,
 	)
-elif host_platform == 'linux'
+else  # linux, bsd, ...
 	data_files += to_array.process(rendered_icons['icon_exe'], extra_args: 'icon_exe_png')
 	data_files += to_array.process(rendered_icons['icon_cps'], extra_args: 'icon_cps_png')
 	data_files += to_array.process('save.xml', extra_args: 'save_xml')


### PR DESCRIPTION
The linux branch of resources processing in fact applies to a lot of POSIX compatible OSes including, for instance, all BSDs, so it makes sense to treat is as default.