### PR TITLE
Fix icon name in desktop file

### DIFF
--- a/resources/powder.template.desktop
+++ b/resources/powder.template.desktop
@@ -5,4 +5,4 @@ Comment=@APPCOMMENT@
 MimeType=application/vnd.powdertoy.save;x-scheme-handler/ptsave;
 Categories=Game;Simulation;
 Exec=@APPEXE@ %u
-Icon=@APPVENDOR@-@APPEXE@
+Icon=@APPEXE@


### PR DESCRIPTION
Not sure what was the purpose of adding @APPVENDOR@ here, but FreeBSD does (and I'm pretty sure that all linux distros would) install the icon under the same name as the application. Otherwise it resolves to `powdetoy-powder-toy` which does not make much sense.