### PR TITLE
Add LITH charge serialization with DTEC

### DIFF
--- a/src/simulation/elements/DTEC.cpp
+++ b/src/simulation/elements/DTEC.cpp
@@ -92,6 +92,14 @@ static int update(UPDATE_FUNC_ARGS)
 					setFilt = true;
 					photonWl = parts[ID(r)].ctype;
 				}
+				if (TYP(r) == PT_LITH)
+				{
+					int wl_bin = parts[ID(r)].ctype / 4;
+					if (wl_bin < 0) wl_bin = 0;
+					if (wl_bin > 25) wl_bin = 25;
+					setFilt = true;
+					photonWl = (0x1F << wl_bin);
+				}
 			}
 	if (setFilt)
 	{


### PR DESCRIPTION
Why?
1. It's faster, easier and takes less space.
2. Forward compatibility - #884 will probably disable LITH reflection (but only if this PR will be accepted) so this will be the only method of doing that.
3. It wouldn't break any old save (please correct me if I'm wrong). Even if lith is next to the dtec it's in most cases because the phot will bounce off it resulting in the same wavelength.