### PR TITLE
Add missing cstdint includes

### DIFF
--- a/src/Format.cpp
+++ b/src/Format.cpp
@@ -7,6 +7,7 @@
 #include <cstring>
 #include <zlib.h>
 #include <cstdio>
+#include <cstdint>
 
 #include "graphics/Graphics.h"
 

--- a/src/common/Platform.cpp
+++ b/src/common/Platform.cpp
@@ -25,6 +25,7 @@
 # include <dirent.h>
 #endif
 #ifdef MACOSX
+# include <cstdint>
 # include <mach-o/dyld.h>
 #endif
 

--- a/src/graphics/FontReader.cpp
+++ b/src/graphics/FontReader.cpp
@@ -4,6 +4,7 @@
 #include "font.bz2.h"
 
 #include <array>
+#include <cstdint>
 
 unsigned char *font_data = nullptr;
 unsigned int *font_ptrs = nullptr;

--- a/src/gui/font/FontEditor.cpp
+++ b/src/gui/font/FontEditor.cpp
@@ -1,4 +1,5 @@
 #include <stdexcept>
+#include <cstdint>
 #include <fstream>
 #include <iterator>
 #include <iomanip>


### PR DESCRIPTION
Some files have been using various fixed-size types (`uint32_t` etc.), which are defined in `stdint.h` / `cstdint`, without including said header file. While this code worked with GCC12 (likely a transitive include), under GCC13 it fails to build due to "unknown type" errors.