### PR TITLE
Add FILT tmp2 modes

### DIFF
--- a/src/simulation/elements/DTEC.cpp
+++ b/src/simulation/elements/DTEC.cpp
@@ -107,7 +107,10 @@ static int update(UPDATE_FUNC_ARGS)
 					ny = y+ry;
 					while (TYP(r)==PT_FILT)
 					{
-						parts[ID(r)].ctype = photonWl;
+						if (parts[ID(r)].tmp2 == 0)
+							parts[ID(r)].ctype = photonWl;
+						else if (parts[ID(r)].tmp2 != 1)
+							break;
 						nx += rx;
 						ny += ry;
 						if (nx<0 || ny<0 || nx>=XRES || ny>=YRES)

--- a/src/simulation/elements/LDTC.cpp
+++ b/src/simulation/elements/LDTC.cpp
@@ -154,7 +154,10 @@ static int update(UPDATE_FUNC_ARGS)
 							parts[ID(rr)].ctype;
 						while (TYP(r) == PT_FILT)
 						{
-							parts[ID(r)].ctype = photonWl;
+							if (parts[ID(r)].tmp2 == 0)
+								parts[ID(r)].ctype = photonWl;
+							else if (parts[ID(r)].tmp2 != 1)
+								break;
 							nx += rx;
 							ny += ry;
 							if (nx < 0 || ny < 0 || nx >= XRES || ny >= YRES)


### PR DESCRIPTION
You often need to serialize some value into just a few pixels of FILT... but it sets all FILTs in the line and even in other directions, breaking the whole thing...
There is the solution - FILT tmp2 modes! (used only by DTEC and LDTC, since other sensor are not commonly used next to the advanced subframe technology)
