### PR TITLE
Refactor for RequestManager

### DIFF
--- a/src/client/http/Request.cpp
+++ b/src/client/http/Request.cpp
@@ -12,7 +12,7 @@ namespace http
 
 	Request::~Request()
 	{
-		if (handle->state != RequestHandle::ready)
+		if (handle->state == RequestHandle::running)
 		{
 			RequestManager::Ref().UnregisterRequest(*this);
 		}

--- a/src/client/http/requestmanager/Common.cpp
+++ b/src/client/http/requestmanager/Common.cpp
@@ -50,17 +50,11 @@ namespace http
 		requestHandlesToRegister.clear();
 		for (auto &requestHandle : requestHandlesToUnregister)
 		{
-			RequestDone(requestHandle);
+			RequestDone(requestHandle.get());
 		}
 		requestHandlesToUnregister.clear();
 
 		return running;
-	}
-
-	void RequestManager::RequestDone(std::shared_ptr<RequestHandle> &requestHandle)
-	{
-		auto toRemove = std::find(requestHandles.begin(), requestHandles.end(), requestHandle);
-		if (toRemove != requestHandles.end()) RemoveRequest(toRemove);
 	}
 
 	void RequestManager::RequestDone(RequestHandle *handle)
@@ -68,11 +62,8 @@ namespace http
 		auto toRemove = std::find_if(requestHandles.begin(), requestHandles.end(), [handle] (const std::shared_ptr<RequestHandle> &sptr) {
 			return handle == sptr.get();
 		});
-		RemoveRequest(toRemove);
-	}
+		if (toRemove == requestHandles.end()) return;
 
-	void RequestManager::RemoveRequest(std::vector<std::shared_ptr<RequestHandle>>::iterator toRemove) {
-		assert(toRemove != requestHandles.end());
 		// swap removed request to end before removing
 		auto swapTo = requestHandles.end() - 1;
 		std::swap(*toRemove, *swapTo);

--- a/src/client/http/requestmanager/Null.cpp
+++ b/src/client/http/requestmanager/Null.cpp
@@ -8,6 +8,15 @@ namespace http
 		return std::make_shared<RequestHandle>(CtorTag{});
 	}
 
+	void RequestManager::Run()
+	{
+		while (true)
+		{
+			bool shouldWait = requestHandles.empty();
+			if (!ProcessEvents(shouldWait)) break;
+		}
+	}
+
 	void RequestManager::InitWorker()
 	{
 	}
@@ -20,6 +29,7 @@ namespace http
 	{
 		requestHandle->statusCode = 604;
 		requestHandle->error = "network support not compiled in";
+		RequestDone(requestHandle);
 	}
 
 	void RequestManager::UnregisterRequestHandle(std::shared_ptr<RequestHandle> requestHandle)
@@ -28,7 +38,6 @@ namespace http
 
 	void RequestManager::Tick()
 	{
-		std::this_thread::sleep_for(std::chrono::milliseconds(TickMs));
 	}
 
 	RequestManagerPtr RequestManager::Create(ByteString newProxy, ByteString newCafile, ByteString newCapath, bool newDisableNetwork)

--- a/src/client/http/requestmanager/Null.cpp
+++ b/src/client/http/requestmanager/Null.cpp
@@ -29,7 +29,7 @@ namespace http
 	{
 		requestHandle->statusCode = 604;
 		requestHandle->error = "network support not compiled in";
-		RequestDone(requestHandle);
+		RequestDone(requestHandle.get());
 	}
 
 	void RequestManager::UnregisterRequestHandle(std::shared_ptr<RequestHandle> requestHandle)

--- a/src/client/http/requestmanager/RequestManager.h
+++ b/src/client/http/requestmanager/RequestManager.h
@@ -69,8 +69,9 @@ namespace http
 		bool disableNetwork;
 
 		std::thread worker;
+		void Run();
 		void InitWorker();
-		void Worker();
+		bool ProcessEvents(bool shouldWait);
 		void ExitWorker();
 
 		std::vector<std::shared_ptr<RequestHandle>> requestHandles;
@@ -83,6 +84,13 @@ namespace http
 		std::vector<std::shared_ptr<RequestHandle>> requestHandlesToUnregister;
 		bool running = true;
 		std::mutex sharedStateMx;
+		std::condition_variable sharedStateCv;
+
+		void RequestDone(std::shared_ptr<RequestHandle> &requestHandle);
+		void RequestDone(RequestHandle *handle);
+
+		// Removes one request
+		void RemoveRequest(std::vector<std::shared_ptr<RequestHandle>>::iterator toRemove);
 
 	protected:
 		RequestManager(ByteString newProxy, ByteString newCafile, ByteString newCapath, bool newDisableNetwork);
@@ -96,7 +104,8 @@ namespace http
 		bool DisableNetwork() const;
 
 		static RequestManagerPtr Create(ByteString newProxy, ByteString newCafile, ByteString newCapath, bool newDisableNetwork);
+
 	};
 
-	constexpr int TickMs = 100;
+	constexpr int TickMs = 25;
 }

--- a/src/client/http/requestmanager/RequestManager.h
+++ b/src/client/http/requestmanager/RequestManager.h
@@ -86,11 +86,8 @@ namespace http
 		std::mutex sharedStateMx;
 		std::condition_variable sharedStateCv;
 
-		void RequestDone(std::shared_ptr<RequestHandle> &requestHandle);
+		// Removes a request from the manager, marking it as done and cancelling if necessary.
 		void RequestDone(RequestHandle *handle);
-
-		// Removes one request
-		void RemoveRequest(std::vector<std::shared_ptr<RequestHandle>>::iterator toRemove);
 
 	protected:
 		RequestManager(ByteString newProxy, ByteString newCafile, ByteString newCapath, bool newDisableNetwork);


### PR DESCRIPTION
- Use condition variables to wake up the worker thread instead of polling. Worker sleeps when there is nothing to do. Request latency should be reduced.
- Request completion is now explicit
- Loop removed from common code to allow easier WebAssembly port