### PR TITLE
Make LDTC copy BIZR, BIZRG and BIZRG's wavelength too.

### DIFF
--- a/src/simulation/elements/LDTC.cpp
+++ b/src/simulation/elements/LDTC.cpp
@@ -67,7 +67,7 @@ constexpr int FLAG_KEEP_SEARCHING = 0x8;
 /* Returns true for particles that activate the special FILT color copying mode */
 static bool phot_data_type(int rt)
 {
-	return rt == PT_FILT || rt == PT_PHOT || rt == PT_BRAY || rt == PT_BIZR || rt == PT_BIZG || rt == BIZS;
+	return rt == PT_FILT || rt == PT_PHOT || rt == PT_BRAY || rt == PT_BIZR || rt == PT_BIZRG || rt == PT_BIZRS;
 }
 
 /* Returns true for particles that start a ray search ("dtec" mode)

--- a/src/simulation/elements/LDTC.cpp
+++ b/src/simulation/elements/LDTC.cpp
@@ -67,7 +67,7 @@ constexpr int FLAG_KEEP_SEARCHING = 0x8;
 /* Returns true for particles that activate the special FILT color copying mode */
 static bool phot_data_type(int rt)
 {
-	return rt == PT_FILT || rt == PT_PHOT || rt == PT_BRAY;
+	return rt == PT_FILT || rt == PT_PHOT || rt == PT_BRAY || rt == PT_BIZR || rt == PT_BIZG || rt == BIZS;
 }
 
 /* Returns true for particles that start a ray search ("dtec" mode)


### PR DESCRIPTION
Recently DTEC got updated to detect the wavelenghts of the elements mentioned in the title. This PR adds that missing ability to LDTC element aswell.