### PR TITLE
Add element PAPR

### DIFF
--- a/src/simulation/Simulation.cpp
+++ b/src/simulation/Simulation.cpp
@@ -3330,9 +3330,9 @@ void Simulation::RecalcFreeParticles(bool do_life_dec)
 					photons[y][x] = PMAP(i, t);
 				else
 				{
-					// Particles are sometimes allowed to go inside INVS and FILT
+					// Particles are sometimes allowed to go inside INVS, FILT, and PAPR
 					// To make particles collide correctly when inside these elements, these elements must not overwrite an existing pmap entry from particles inside them
-					if (!pmap[y][x] || (t!=PT_INVIS && t!= PT_FILT))
+					if (!pmap[y][x] || (t!=PT_INVIS && t!= PT_FILT && t != PT_PAPR))
 						pmap[y][x] = PMAP(i, t);
 					// (there are a few exceptions, including energy particles - currently no limit on stacking those)
 					if (t!=PT_THDR && t!=PT_EMBR && t!=PT_FIGH && t!=PT_PLSM)

--- a/src/simulation/Simulation.cpp
+++ b/src/simulation/Simulation.cpp
@@ -1094,6 +1094,10 @@ int Simulation::eval_move(int pt, int nx, int ny, unsigned *rr) const
 					return 0;
 			}
 			break;
+		case PT_PAPR:
+			// May allow PAPR to block particles when marked? Or would that be too contrived?
+			result = 2;
+			break;
 		default:
 			// This should never happen
 			// If it were to happen, try_move would interpret a 3 as a 1

--- a/src/simulation/Simulation.cpp
+++ b/src/simulation/Simulation.cpp
@@ -1095,8 +1095,12 @@ int Simulation::eval_move(int pt, int nx, int ny, unsigned *rr) const
 			}
 			break;
 		case PT_PAPR:
-			// May allow PAPR to block particles when marked? Or would that be too contrived?
-			result = 2;
+			// BCOL can always pass through PAPR in order to color it
+			// Most elements are blocked by marked PAPR, except for certified "weird" elements where it's inverse
+			if ((pt == PT_BCOL) || ((parts[ID(r)].life >> 24) & 0x01 ^ (pt != PT_ANAR && pt != PT_BIZR && pt != PT_BIZRG)))
+				result = 2;
+			else
+				result = 0;
 			break;
 		default:
 			// This should never happen

--- a/src/simulation/SimulationData.cpp
+++ b/src/simulation/SimulationData.cpp
@@ -185,6 +185,10 @@ void SimulationData::init_can_move()
 		//SAWD cannot be displaced by other powders
 		if (elements[movingType].Properties & TYPE_PART)
 			can_move[movingType][PT_SAWD] = 0;
+
+		// Let most non-solids pass through PAPR
+        if (elements[movingType].Properties & (TYPE_GAS | TYPE_PART | TYPE_LIQUID))
+            can_move[movingType][PT_PAPR] = 2;
 	}
 	//a list of lots of things PHOT can move through
 	// TODO: replace with property

--- a/src/simulation/SimulationData.cpp
+++ b/src/simulation/SimulationData.cpp
@@ -186,9 +186,9 @@ void SimulationData::init_can_move()
 		if (elements[movingType].Properties & TYPE_PART)
 			can_move[movingType][PT_SAWD] = 0;
 
-		// Let most non-solids pass through PAPR
+		// Let most non-solids pass through unmarked PAPR
         if (elements[movingType].Properties & (TYPE_GAS | TYPE_PART | TYPE_LIQUID) && (movingType != PT_FIRE && movingType != PT_SMKE))
-            can_move[movingType][PT_PAPR] = 2;
+            can_move[movingType][PT_PAPR] = 3;
 	}
 	//a list of lots of things PHOT can move through
 	// TODO: replace with property

--- a/src/simulation/SimulationData.cpp
+++ b/src/simulation/SimulationData.cpp
@@ -187,7 +187,7 @@ void SimulationData::init_can_move()
 			can_move[movingType][PT_SAWD] = 0;
 
 		// Let most non-solids pass through PAPR
-        if (elements[movingType].Properties & (TYPE_GAS | TYPE_PART | TYPE_LIQUID))
+        if (elements[movingType].Properties & (TYPE_GAS | TYPE_PART | TYPE_LIQUID) && (movingType != PT_FIRE && movingType != PT_SMKE))
             can_move[movingType][PT_PAPR] = 2;
 	}
 	//a list of lots of things PHOT can move through

--- a/src/simulation/elements/ARAY.cpp
+++ b/src/simulation/elements/ARAY.cpp
@@ -165,6 +165,30 @@ static int update(UPDATE_FUNC_ARGS)
 								{
 									parts[r].life = 10;
 								}
+							}
+							else if (rt == PT_PAPR)
+							{
+								if (parts[r].tmp)
+								{
+									if (parts[r].tmp & 0x10)
+									{
+										// Read
+										if ((parts[r].life >> 24) & 0x1)
+										{
+											break;
+										}
+									}
+									else
+									{
+										// Write
+										parts[r].life = 0x11A2222;
+									}
+								}
+								else
+								{
+									// Enter writing state
+									parts[r].tmp = 0x0A;
+								}
 							// this if prevents BRAY from stopping on certain materials
 							}
 							else if (rt != PT_INWR && (rt != PT_SPRK || parts[r].ctype != PT_INWR) && rt != PT_ARAY && rt != PT_WIFI && !(rt == PT_SWCH && parts[r].life >= 10))
@@ -189,7 +213,7 @@ static int update(UPDATE_FUNC_ARGS)
 									parts[r].dcolour = 0xFF000000;
 							//this if prevents red BRAY from stopping on certain materials
 							}
-							else if (rt==PT_STOR || rt==PT_INWR || (rt==PT_SPRK && parts[r].ctype==PT_INWR) || rt==PT_ARAY || rt==PT_WIFI || rt==PT_FILT || (rt==PT_SWCH && parts[r].life>=10))
+							else if (rt==PT_STOR || rt==PT_INWR || (rt==PT_SPRK && parts[r].ctype==PT_INWR) || rt==PT_ARAY || rt==PT_WIFI || rt==PT_FILT || (rt==PT_SWCH && parts[r].life>=10) || rt==PT_PAPR)
 							{
 								if (rt == PT_STOR)
 								{
@@ -200,6 +224,30 @@ static int update(UPDATE_FUNC_ARGS)
 								{
 									isBlackDeco = (parts[r].dcolour==0xFF000000);
 									parts[r].life = 2;
+								}
+								else if (rt == PT_PAPR)
+								{
+									if (parts[r].tmp)
+									{
+										if (parts[r].tmp & 0x10)
+										{
+											// Read
+											if ((parts[r].life >> 24) & 0x1)
+											{
+												break;
+											}
+										}
+										else
+										{
+											// Write
+											parts[r].life = 0x0;
+										}
+									}
+									else
+									{
+										// Enter reading state
+										parts[r].tmp = 0x1A;
+									}
 								}
 								docontinue = 1;
 							}

--- a/src/simulation/elements/FIRE.cpp
+++ b/src/simulation/elements/FIRE.cpp
@@ -195,6 +195,11 @@ int Element_FIRE_update(UPDATE_FUNC_ARGS)
 						}
 					}
 				}
+				// Make paper burn more reliably
+				if (rt==PT_PAPR)
+				{
+					parts[ID(r)].temp += 4;
+				}
 
 				if (t == PT_LAVA)
 				{

--- a/src/simulation/elements/LDTC.cpp
+++ b/src/simulation/elements/LDTC.cpp
@@ -104,7 +104,7 @@ static int update(UPDATE_FUNC_ARGS)
 				if (!r)
 					continue;
 				bool boolMode = accepted_conductor(sim, r);
-				bool filtMode = copyColor && TYP(r) == PT_FILT;
+				bool filtMode = copyColor && (TYP(r) == PT_FILT || TYP(r) == PT_PAPR);
 				if (!boolMode && !filtMode)
 					continue;
 
@@ -147,21 +147,59 @@ static int update(UPDATE_FUNC_ARGS)
 
 					if (filtMode)
 					{
-						if (!phot_data_type(TYP(rr)))
+						if (!phot_data_type(TYP(rr)) && TYP(rr) != PT_PAPR)
 							continue;
 
 						int nx = x + rx, ny = y + ry;
 						int photonWl = TYP(rr) == PT_FILT ?
 							Element_FILT_getWavelengths(&parts[ID(rr)]) :
 							parts[ID(rr)].ctype;
-						while (TYP(r) == PT_FILT)
+						if (TYP(rr) == PT_PAPR)
 						{
-							parts[ID(r)].ctype = photonWl;
-							nx += rx;
-							ny += ry;
-							if (nx < 0 || ny < 0 || nx >= XRES || ny >= YRES)
-								break;
-							r = pmap[ny][nx];
+							photonWl = 0x0;
+							int bit = 0x1;
+							while (TYP(rr) == PT_PAPR && bit <= 0x3FFFFFFF)
+							{
+								if ((parts[ID(rr)].life >> 24) & 0x1)
+								{
+									photonWl |= bit;
+								}
+								xCurrent += xStep;
+								yCurrent += yStep;
+								if (xCurrent < 0 || yCurrent < 0 || xCurrent >= XRES || yCurrent >= YRES)
+									break;
+								rr = pmap[yCurrent][xCurrent];
+								bit <<= 1;
+							}
+						}
+						if (TYP(r) == PT_FILT)
+						{
+							while (TYP(r) == PT_FILT)
+							{
+								parts[ID(r)].ctype = photonWl;
+								nx += rx;
+								ny += ry;
+								if (nx < 0 || ny < 0 || nx >= XRES || ny >= YRES)
+									break;
+								r = pmap[ny][nx];
+							}
+						}
+						if (TYP(r) == PT_PAPR)
+						{
+							int bit = 0x1;
+							while (TYP(r) == PT_PAPR && bit <= 0x3FFFFFFF)
+							{
+								if (photonWl & bit)
+								 	parts[ID(r)].life = 0x1080820;
+								else
+								 	parts[ID(r)].life = 0x0;
+								nx += rx;
+								ny += ry;
+								if (nx < 0 || ny < 0 || nx >= XRES || ny >= YRES)
+									break;
+								r = pmap[ny][nx];
+								bit <<= 1; 
+							}
 						}
 						break;
 					}

--- a/src/simulation/elements/PAPR.cpp
+++ b/src/simulation/elements/PAPR.cpp
@@ -8,8 +8,8 @@ static int graphics(GRAPHICS_FUNC_ARGS);
 // Additionally, it can be read and written to by ARAY.
 
 // Property usage:
-// life: Temporary read/write state for ARAY interaction
-// tmp: Written color value. If dcolour is not black, it gets copied here. 1 bit alpha
+// life: Written color value. If dcolour is not black, it gets copied here. 1 bit alpha
+// tmp: Temporary read/write state for ARAY interaction
 // tmp2: Singe level
 
 void Element::Element_PAPR()
@@ -58,6 +58,7 @@ void Element::Element_PAPR()
 
 static int update(UPDATE_FUNC_ARGS)
 {
+	// Char when above burning temperature
 	if (parts[i].temp > 450 && parts[i].temp >= parts[i].tmp2)
 	{
 		parts[i].tmp2 = (int)parts[i].temp;
@@ -73,7 +74,6 @@ static int update(UPDATE_FUNC_ARGS)
 			if (np >= 0)
 			{
 				parts[np].life = 70;
-				// parts[np].temp = parts[i].temp;
 			}
 		}
 	}
@@ -82,6 +82,7 @@ static int update(UPDATE_FUNC_ARGS)
 
 static int graphics(GRAPHICS_FUNC_ARGS)
 {
+	// Darken when burnt
 	float maxtemp = std::max((float)cpart->tmp2, cpart->temp);
 	if (maxtemp > 450)
 	{

--- a/src/simulation/elements/PAPR.cpp
+++ b/src/simulation/elements/PAPR.cpp
@@ -8,7 +8,7 @@ static int graphics(GRAPHICS_FUNC_ARGS);
 // Additionally, it can be read and written to by ARAY.
 
 // Property usage:
-// life: Written color value. If dcolour is not black, it gets copied here. 1 bit alpha
+// life: Written color value. Uses same format as dcolour.
 // tmp: Temporary read/write state for ARAY interaction
 // tmp2: Singe level
 
@@ -77,11 +77,55 @@ static int update(UPDATE_FUNC_ARGS)
 			}
 		}
 	}
+
+	// Get marked by BCOL
+	if (TYP(pmap[y][x]) == PT_BCOL)
+	{
+		parts[i].life = 0x122222A;
+	}
+
+	// Get unmarked by SOAP
+	for (auto rx = -1; rx <= 1; rx++)
+	{
+		for (auto ry = -1; ry <= 1; ry++)
+		{
+			if (rx || ry)
+			{
+				auto r = pmap[y+ry][x+rx];
+				if (!r)
+					continue;
+				if (TYP(r) == PT_SOAP)
+				{
+					parts[i].life = 0;
+				}
+			}
+		}
+	}
+
+	// Decrement tmp counter for laser reading/writing
+	if (parts[i].tmp & 0xF)
+	{
+		parts[i].tmp--;
+	}
+	else
+	{
+		parts[i].tmp = 0;
+	}
 	return 0;
 }
 
 static int graphics(GRAPHICS_FUNC_ARGS)
 {
+	int ta = (cpart->life >> 24) & 0x01;
+	int tr = (cpart->life >> 16) & 0xFF;
+	int tg = (cpart->life >> 8) & 0xFF;
+	int tb = (cpart->life) & 0xFF;
+	if (ta)
+	{
+		*colr = tr;
+		*colg = tg;
+		*colb = tb;
+	}
 	// Darken when burnt
 	float maxtemp = std::max((float)cpart->tmp2, cpart->temp);
 	if (maxtemp > 450)

--- a/src/simulation/elements/PAPR.cpp
+++ b/src/simulation/elements/PAPR.cpp
@@ -1,0 +1,81 @@
+#include "simulation/ElementCommon.h"
+
+static int update(UPDATE_FUNC_ARGS);
+static int graphics(GRAPHICS_FUNC_ARGS);
+
+void Element::Element_PAPR()
+{
+	Identifier = "DEFAULT_PT_PAPR";
+	Name = "PAPR";
+	Colour = 0xF3F3CA_rgb;
+	MenuVisible = 1;
+	MenuSection = SC_SOLIDS;
+	Enabled = 1;
+
+	Advection = 0.0f;
+	AirDrag = 0.00f * CFDS;
+	AirLoss = 0.90f;
+	Loss = 0.00f;
+	Collision = 0.0f;
+	Gravity = 0.0f;
+	Diffusion = 0.00f;
+	HotAir = 0.000f	* CFDS;
+	Falldown = 0;
+
+	Flammable = 20;
+	Explosive = 0;
+	Meltable = 0;
+	Hardness = 15;
+
+	Weight = 100;
+
+	HeatConduct = 164;
+	Description = "Paper. Flammable, readable, writable.";
+
+	Properties = TYPE_SOLID | PROP_NEUTPENETRATE;
+
+	LowPressure = IPL;
+	LowPressureTransition = NT;
+	HighPressure = IPH;
+	HighPressureTransition = NT;
+	LowTemperature = ITL;
+	LowTemperatureTransition = NT;
+	HighTemperature = 873.0f;
+	HighTemperatureTransition = PT_FIRE;
+
+	Update = &update;
+	Graphics = &graphics;
+}
+
+static int update(UPDATE_FUNC_ARGS)
+{
+	if (parts[i].temp > 450 && parts[i].temp > parts[i].tmp)
+		parts[i].tmp = (int)parts[i].temp;
+
+	if (parts[i].temp > 773.0f && sim->pv[y/CELL][x/CELL] <= -10.0f)
+	{
+		float temp = parts[i].temp;
+		sim->create_part(i, x, y, PT_BCOL);
+		parts[i].temp = temp;
+	}
+
+	return 0;
+}
+
+static int graphics(GRAPHICS_FUNC_ARGS)
+{
+	float maxtemp = std::max((float)cpart->tmp, cpart->temp);
+	if (maxtemp > 400)
+	{
+		*colr -= (int)restrict_flt((maxtemp-400)/3,0,172);
+		*colg -= (int)restrict_flt((maxtemp-400)/4,0,140);
+		*colb -= (int)restrict_flt((maxtemp-400)/20,0,44);
+	}
+	if (maxtemp < 273)
+	{
+		*colr -= (int)restrict_flt((273-maxtemp)/5,0,40);
+		*colg += (int)restrict_flt((273-maxtemp)/4,0,40);
+		*colb += (int)restrict_flt((273-maxtemp)/1.5,0,150);
+	}
+	return 0;
+}

--- a/src/simulation/elements/PAPR.cpp
+++ b/src/simulation/elements/PAPR.cpp
@@ -3,6 +3,15 @@
 static int update(UPDATE_FUNC_ARGS);
 static int graphics(GRAPHICS_FUNC_ARGS);
 
+// Element overview:
+// PAPR (Paper) is a flammable solid element that can be colored by certain other elements.
+// Additionally, it can be read and written to by ARAY.
+
+// Property usage:
+// life: Temporary read/write state for ARAY interaction
+// tmp: Written color value. If dcolour is not black, it gets copied here. 1 bit alpha
+// tmp2: Singe level
+
 void Element::Element_PAPR()
 {
 	Identifier = "DEFAULT_PT_PAPR";
@@ -14,7 +23,7 @@ void Element::Element_PAPR()
 
 	Advection = 0.0f;
 	AirDrag = 0.00f * CFDS;
-	AirLoss = 0.90f;
+	AirLoss = 0.995f;
 	Loss = 0.00f;
 	Collision = 0.0f;
 	Gravity = 0.0f;
@@ -22,14 +31,14 @@ void Element::Element_PAPR()
 	HotAir = 0.000f	* CFDS;
 	Falldown = 0;
 
-	Flammable = 20;
+	Flammable = 0;
 	Explosive = 0;
 	Meltable = 0;
 	Hardness = 15;
 
 	Weight = 100;
 
-	HeatConduct = 164;
+	HeatConduct = 80;
 	Description = "Paper. Flammable, readable, writable.";
 
 	Properties = TYPE_SOLID | PROP_NEUTPENETRATE;
@@ -40,8 +49,8 @@ void Element::Element_PAPR()
 	HighPressureTransition = NT;
 	LowTemperature = ITL;
 	LowTemperatureTransition = NT;
-	HighTemperature = 873.0f;
-	HighTemperatureTransition = PT_FIRE;
+	HighTemperature = 700.0f;
+	HighTemperatureTransition = PT_NONE; // Add ash or broken paper element?
 
 	Update = &update;
 	Graphics = &graphics;
@@ -49,33 +58,36 @@ void Element::Element_PAPR()
 
 static int update(UPDATE_FUNC_ARGS)
 {
-	if (parts[i].temp > 450 && parts[i].temp > parts[i].tmp)
-		parts[i].tmp = (int)parts[i].temp;
-
-	if (parts[i].temp > 773.0f && sim->pv[y/CELL][x/CELL] <= -10.0f)
+	if (parts[i].temp > 450 && parts[i].temp >= parts[i].tmp2)
 	{
-		float temp = parts[i].temp;
-		sim->create_part(i, x, y, PT_BCOL);
-		parts[i].temp = temp;
+		parts[i].tmp2 = (int)parts[i].temp;
 	}
 
+	// Auto-ignition temperature
+	if (parts[i].temp > (451.0f - 32.f) / 1.8f + 273.15f)
+	{
+		parts[i].temp += 1;
+		if (sim->rng.chance((int)parts[i].temp-450,400))
+		{
+			int np = sim->create_part(-1, x + sim->rng.between(-1, 1), y + sim->rng.between(-1, 1), PT_FIRE);
+			if (np >= 0)
+			{
+				parts[np].life = 70;
+				// parts[np].temp = parts[i].temp;
+			}
+		}
+	}
 	return 0;
 }
 
 static int graphics(GRAPHICS_FUNC_ARGS)
 {
-	float maxtemp = std::max((float)cpart->tmp, cpart->temp);
-	if (maxtemp > 400)
+	float maxtemp = std::max((float)cpart->tmp2, cpart->temp);
+	if (maxtemp > 450)
 	{
-		*colr -= (int)restrict_flt((maxtemp-400)/3,0,172);
-		*colg -= (int)restrict_flt((maxtemp-400)/4,0,140);
-		*colb -= (int)restrict_flt((maxtemp-400)/20,0,44);
-	}
-	if (maxtemp < 273)
-	{
-		*colr -= (int)restrict_flt((273-maxtemp)/5,0,40);
-		*colg += (int)restrict_flt((273-maxtemp)/4,0,40);
-		*colb += (int)restrict_flt((273-maxtemp)/1.5,0,150);
+		*colr -= (int)restrict_flt((maxtemp-450)*1.2f,0,230);
+		*colg -= (int)restrict_flt((maxtemp-450)*1.4f,0,230);
+		*colb -= (int)restrict_flt((maxtemp-450)*1.7f,0,197);
 	}
 	return 0;
 }

--- a/src/simulation/elements/meson.build
+++ b/src/simulation/elements/meson.build
@@ -191,6 +191,7 @@ simulation_elem_names = [
 	'VSNS',
 	'ROCK',
 	'LITH',
+	'PAPR',
 ]
 
 simulation_elem_src = []


### PR DESCRIPTION
PAPR is a new element implementing my take on the common suggestion.

Beyond just being another flammable element, PAPR can exist in two states: "marked" and "unmarked." When unmarked, it allows most non-solid particles to pass through, but when marked, it becomes solid. A simple way to mark and unmark PAPR is using BCOL and SOAP, respectively.
![Ed9yFCBjlM](https://github.com/The-Powder-Toy/The-Powder-Toy/assets/59275598/b6868dd1-88bf-4444-953c-b4523f76555a)

Additionally, the element has a few features meant to facilitate more advanced creations. For example, it can be read/written using ARAY:
- Hit it with two normal ARAY beams in quick succession to mark it.
- Hit it with a normal ARAY beam followed by a PSCN ARAY beam to unmark it.
- Hit it with a PSCN ARAY beam and, if marked, it will block the next ARAY beam (of either type) that hits it in quick succession.
The ideas for these reactions aren't totally finalized. I designed them to try and be consistent with the properties of ARAY and how either beam type tends to work, but this set of reactions feels slightly difficult to work with in the way I intended.
![powder_LpLsAyA8O3](https://github.com/The-Powder-Toy/The-Powder-Toy/assets/59275598/e481e0f8-996f-49be-8ecd-35f98281516d)
I could see this being used to create devices such as plotters, printers, and photocopiers (fittingly), as well as "filters" that use the physical properties of marked/unmarked paper.

Finally, LDTC can be used to read/write FILT wavelengths to or from PAPR, with each particle representing a single bit from the wavelength.
![vsoLj9nrRC](https://github.com/The-Powder-Toy/The-Powder-Toy/assets/59275598/4354f1de-03bc-496f-99f9-61835733c281)

As a small extra touch, each method of marking PAPR produces a slightly different color. Marked PAPR can technically be any color because the property used to store whether or not it's marked stores RGB values as well.

Note that I'm not very familiar with the conventions of C++ or this repository. If I've done anything here that violates best practice, please let me know. I'm also open to feedback on any ways I can improve the element, such as changing features to be more practical or intuitive as well as bugs or any other tweaks.