### PR TITLE
Add color to flames

### DIFF
--- a/src/graphics/Renderer.h
+++ b/src/graphics/Renderer.h
@@ -158,6 +158,7 @@ public:
 	RENDERER_TABLE(heatTable)
 	RENDERER_TABLE(clfmTable)
 	RENDERER_TABLE(firwTable)
+	RENDERER_TABLE(flameAchromaTable)
 #undef RENDERER_TABLE
 	static void PopulateTables();
 

--- a/src/graphics/RendererBasic.cpp
+++ b/src/graphics/RendererBasic.cpp
@@ -170,6 +170,7 @@ std::vector<RGB<uint8_t>> Renderer::plasmaTable;
 std::vector<RGB<uint8_t>> Renderer::heatTable;
 std::vector<RGB<uint8_t>> Renderer::clfmTable;
 std::vector<RGB<uint8_t>> Renderer::firwTable;
+std::vector<RGB<uint8_t>> Renderer::flameAchromaTable;
 static bool tablesPopulated = false;
 static std::mutex tablesPopulatedMx;
 void Renderer::PopulateTables()
@@ -220,6 +221,10 @@ void Renderer::PopulateTables()
 			{ 0x00FF00_rgb, 0.60f },
 			{ 0xFFFF00_rgb, 0.80f },
 			{ 0xFF0000_rgb, 1.00f },
+		}, 200);
+		flameAchromaTable = Graphics::Gradient({
+			{ 0x000000_rgb, 0.00f },
+			{ 0xFFFFFF_rgb, 1.00f },
 		}, 200);
 	}
 }

--- a/src/simulation/elements/FIRE.cpp
+++ b/src/simulation/elements/FIRE.cpp
@@ -275,6 +275,50 @@ int Element_FIRE_update(UPDATE_FUNC_ARGS)
 					parts[ID(r)].tmp = parts[ID(r)].ctype = 0;
 					if (elements[rt].Explosive)
 						sim->pv[y/CELL][x/CELL] += 0.25f * CFDS;
+					parts[ID(r)].dcolour = 0;
+					if (rt == PT_NITR)
+						parts[ID(r)].dcolour = 0xffa000;
+					if (rt == PT_COAL || rt == PT_BCOL)
+						parts[ID(r)].dcolour = 0x005050;
+					if (rt == PT_DUST || rt == PT_WOOD)
+						parts[ID(r)].dcolour = 0x000070;
+					if (rt == PT_ACID)
+						parts[ID(r)].dcolour = 0x00a000;
+					if (rt == PT_OIL || rt == PT_GAS)
+						parts[ID(r)].dcolour = 0xc0c0ff;
+					if (rt == PT_INSL)
+						parts[ID(r)].dcolour = 0x500050;
+					if (rt == PT_RBDM || rt == PT_LRBD) {
+						parts[ID(r)].dcolour = 0x505080;
+						parts[ID(r)].tmp2 |= 1;
+					}
+					parts[ID(r)].dcolour = 
+						(
+							(
+								(
+									( (parts[i].dcolour&0xFF000000)>>24 ) + ( (parts[ID(r)].dcolour&0xFF000000)>>24 )*2
+								) /3
+							)<<24
+						) | (
+							(
+								(
+									( (parts[i].dcolour&0x00FF0000)>>16 ) + ( (parts[ID(r)].dcolour&0x00FF0000)>>16 )*2
+								) /3
+							)<<16
+						) | (
+							(
+								(
+									( (parts[i].dcolour&0x0000FF00)>>8 ) + ( (parts[ID(r)].dcolour&0x0000FF00)>>8)*2
+								) /3 
+							)<<8
+						) | (
+							(
+								( 
+									( (parts[i].dcolour&0x000000FF) ) + ( parts[ID(t)].dcolour&0x000000FF )*2
+								) /3
+							)<<0
+						)
+					;
 				}
 			}
 		}
@@ -365,15 +409,13 @@ static int updateLegacy(UPDATE_FUNC_ARGS)
 
 static int graphics(GRAPHICS_FUNC_ARGS)
 {
-	RGB<uint8_t> color = Renderer::flameTableAt(cpart->life);
-	*colr = color.Red;
-	*colg = color.Green;
-	*colb = color.Blue;
+	RGB<uint8_t> color = cpart->tmp2&1 ? Renderer::flameAchromaTableAt(cpart->life) : Renderer::flameTableAt(cpart->life);
+	RGB<uint8_t> c = RGB<uint8_t>::Unpack(cpart->dcolour & 0xFFFFFF);
 
 	*firea = 255;
-	*firer = *colr;
-	*fireg = *colg;
-	*fireb = *colb;
+	*firer = *colr = color.Red*(255-c.Red)/255;
+	*fireg = *colg = color.Green*(255-c.Green)/255;
+	*fireb = *colb = color.Blue*(255-c.Blue)/255;
 
 	*pixel_mode = PMODE_NONE; //Clear default, don't draw pixel
 	*pixel_mode |= FIRE_ADD;

--- a/src/simulation/elements/H2.cpp
+++ b/src/simulation/elements/H2.cpp
@@ -82,6 +82,8 @@ static int update(UPDATE_FUNC_ARGS)
 						sim->create_part(i,x,y,PT_FIRE);
 						parts[i].temp += sim->rng.between(0, 99);
 						parts[i].tmp |= 1;
+						parts[ID(r)].dcolour = 0x00a050;
+						parts[i].dcolour = 0x00a050;
 						return 1;
 					}
 					else if ((rt==PT_PLSM && !(parts[ID(r)].tmp&4)) || (rt==PT_LAVA && parts[ID(r)].ctype != PT_BMTL))
@@ -89,6 +91,7 @@ static int update(UPDATE_FUNC_ARGS)
 						sim->create_part(i,x,y,PT_FIRE);
 						parts[i].temp += sim->rng.between(0, 99);
 						parts[i].tmp |= 1;
+						parts[i].dcolour = 0x00a050;
 						return 1;
 					}
 				}


### PR DESCRIPTION
* Flames now have a color based on their decoration color (works like an absorption spectrum)
* NITR - blue/green
* HYGN - red
* ACID - pink-ish
* OIL/GAS - purple-ish
* RBDM/LRBD - white
* INSL - green
* COAL/BCOL/DUST - tiny changes, could probably be removed, though

https://github.com/The-Powder-Toy/The-Powder-Toy/assets/91527355/41906ebb-a629-4d72-a48f-6dd80e7629ac
