### PR TITLE
add OpenBSD to platforms using exit(3)

### DIFF
--- a/src/PowderToy.cpp
+++ b/src/PowderToy.cpp
@@ -157,7 +157,7 @@ static void BlueScreen(String detailMessage, std::optional<std::vector<String>> 
 	}
 
 	// Don't use Platform::Exit, we're practically zombies at this point anyway.
-#if defined(__MINGW32__) || defined(__APPLE__) || defined(__EMSCRIPTEN__)
+#if defined(__MINGW32__) || defined(__APPLE__) || defined(__EMSCRIPTEN__) || defined(__OpenBSD__)
 	// Come on...
 	exit(-1);
 #else


### PR DESCRIPTION
simple addition of `__OpenBSD__` to the ifdef. Is the only patch needed to run this on OpenBSD like on the other platforms (except for a few flags for meson set in the port Makefile).