### PR TITLE
Make INWR behavior consistent for ARAY, DRAY and FRAY

### DIFF
--- a/src/client/GameSave.cpp
+++ b/src/client/GameSave.cpp
@@ -1245,6 +1245,14 @@ void GameSave::readOPS(const std::vector<char> &data)
 							particles[newIndex].tmp = builtinGol[particles[newIndex].ctype].colour2.Pack();
 						}
 					}
+					break;
+				case PT_ARAY:
+				case PT_CRAY:
+				case PT_FRAY:
+					if (savedVersion < 99 && !fakeNewerVersion)
+					{
+						particles[newIndex].flags |= FLAG_INWRDIAGONAL;
+					}
 				}
 				if (PressureInTmp3(particles[newIndex].type))
 				{

--- a/src/client/GameSave.cpp
+++ b/src/client/GameSave.cpp
@@ -1196,10 +1196,6 @@ void GameSave::readOPS(const std::vector<char> &data)
 					}
 					break;
 				case PT_CRAY:
-					if (savedVersion < 99 && !fakeNewerVersion)
-					{
-						particles[newIndex].flags |= FLAG_INWRDIAGONAL;
-					}
 					if (savedVersion < 91)
 					{
 						if (particles[newIndex].tmp2)

--- a/src/client/GameSave.cpp
+++ b/src/client/GameSave.cpp
@@ -1196,6 +1196,10 @@ void GameSave::readOPS(const std::vector<char> &data)
 					}
 					break;
 				case PT_CRAY:
+					if (savedVersion < 99 && !fakeNewerVersion)
+					{
+						particles[newIndex].flags |= FLAG_INWRDIAGONAL;
+					}
 					if (savedVersion < 91)
 					{
 						if (particles[newIndex].tmp2)
@@ -1247,7 +1251,6 @@ void GameSave::readOPS(const std::vector<char> &data)
 					}
 					break;
 				case PT_ARAY:
-				case PT_CRAY:
 				case PT_FRAY:
 					if (savedVersion < 99 && !fakeNewerVersion)
 					{

--- a/src/simulation/ElementDefs.h
+++ b/src/simulation/ElementDefs.h
@@ -37,7 +37,7 @@ constexpr auto FLAG_SKIPMOVE      = UINT32_C(0x00000002); // skip movement for o
 //#define FLAG_WATEREQUAL 0x4 //if a liquid was already checked during equalization
 constexpr auto FLAG_MOVABLE       = UINT32_C(0x00000008); // compatibility with old saves (moving SPNG), only applies to SPNG
 constexpr auto FLAG_PHOTDECO      = UINT32_C(0x00000008); // compatibility with old saves (decorated photons), only applies to PHOT. Having the same value as FLAG_MOVABLE is fine because they apply to different elements, and this saves space for future flags,
-constexpr auto FLAG_INWRDIAGONAL  = UINT32_C(0x00000008); // compatibility with old saves (inwr sparks on diagonals), only applies to ARAY, CRAY and FRAY.
+constexpr auto FLAG_INWRDIAGONAL  = UINT32_C(0x00000008); // compatibility with old saves (INWR sparks on diagonals), only applies to ARAY, CRAY and FRAY.
 
 
 #define UPDATE_FUNC_ARGS Simulation* sim, int i, int x, int y, int surround_space, int nt, Particle *parts, int pmap[YRES][XRES]

--- a/src/simulation/ElementDefs.h
+++ b/src/simulation/ElementDefs.h
@@ -37,6 +37,7 @@ constexpr auto FLAG_SKIPMOVE      = UINT32_C(0x00000002); // skip movement for o
 //#define FLAG_WATEREQUAL 0x4 //if a liquid was already checked during equalization
 constexpr auto FLAG_MOVABLE       = UINT32_C(0x00000008); // compatibility with old saves (moving SPNG), only applies to SPNG
 constexpr auto FLAG_PHOTDECO      = UINT32_C(0x00000008); // compatibility with old saves (decorated photons), only applies to PHOT. Having the same value as FLAG_MOVABLE is fine because they apply to different elements, and this saves space for future flags,
+constexpr auto FLAG_INWRDIAGONAL  = UINT32_C(0x00000008); // compatibility with old saves (inwr sparks on diagonals), only applies to ARAY, CRAY and FRAY.
 
 
 #define UPDATE_FUNC_ARGS Simulation* sim, int i, int x, int y, int surround_space, int nt, Particle *parts, int pmap[YRES][XRES]

--- a/src/simulation/elements/ARAY.cpp
+++ b/src/simulation/elements/ARAY.cpp
@@ -64,8 +64,12 @@ static int update(UPDATE_FUNC_ARGS)
 				if (TYP(r) == PT_SPRK && parts[ID(r)].life == 3)
 				{
 					bool isBlackDeco = false;
-					int destroy = (parts[ID(r)].ctype==PT_PSCN) ? 1 : 0;
-					int nostop = (parts[ID(r)].ctype==PT_INST) ? 1 : 0;
+					bool destroy = parts[ID(r)].ctype==PT_PSCN;
+					bool nostop = parts[ID(r)].ctype==PT_INST;
+					
+					if (parts[ID(r)].ctype == PT_INWR && rx && ry && !(parts[i].flags & FLAG_INWRDIAGONAL)) // INWR doesn't spark from diagonals
+						continue;
+					
 					int colored = 0, rt;
 					for (int docontinue = 1, nxx = 0, nyy = 0, nxi = rx*-1, nyi = ry*-1; docontinue; nyy+=nyi, nxx+=nxi)
 					{

--- a/src/simulation/elements/CRAY.cpp
+++ b/src/simulation/elements/CRAY.cpp
@@ -90,7 +90,11 @@ static int update(UPDATE_FUNC_ARGS)
 						unsigned int colored = 0;
 						bool destroy = parts[ID(r)].ctype==PT_PSCN;
 						bool nostop = parts[ID(r)].ctype==PT_INST;
-						bool createSpark = (parts[ID(r)].ctype==PT_INWR);
+						bool createSpark = parts[ID(r)].ctype==PT_INWR;
+						
+						if (createSpark && rx && ry && !(parts[i].flags & FLAG_INWRDIAGONAL)) // INWR doesn't spark from diagonals
+							continue;
+						
 						int partsRemaining = 255;
 						if (parts[i].tmp) //how far it shoots
 							partsRemaining = parts[i].tmp;
@@ -104,6 +108,7 @@ static int update(UPDATE_FUNC_ARGS)
 							if (!sim->IsWallBlocking(x+nxi+nxx, y+nyi+nyy, TYP(parts[i].ctype)) && (!sim->pmap[y+nyi+nyy][x+nxi+nxx] || createSpark)) { // create, also set color if it has passed through FILT
 								int nr = sim->create_part(-1, x+nxi+nxx, y+nyi+nyy, TYP(parts[i].ctype), ID(parts[i].ctype));
 								if (nr!=-1) {
+									parts[nr].flags |= parts[i].flags & FLAG_INWRDIAGONAL; // ensure INWR backwards compatibility for created parts
 									if (colored)
 										parts[nr].dcolour = colored;
 									parts[nr].temp = parts[i].temp;

--- a/src/simulation/elements/CRAY.cpp
+++ b/src/simulation/elements/CRAY.cpp
@@ -91,10 +91,6 @@ static int update(UPDATE_FUNC_ARGS)
 						bool destroy = parts[ID(r)].ctype==PT_PSCN;
 						bool nostop = parts[ID(r)].ctype==PT_INST;
 						bool createSpark = parts[ID(r)].ctype==PT_INWR;
-						
-						if (createSpark && rx && ry && !(parts[i].flags & FLAG_INWRDIAGONAL)) // INWR doesn't spark from diagonals
-							continue;
-						
 						int partsRemaining = 255;
 						if (parts[i].tmp) //how far it shoots
 							partsRemaining = parts[i].tmp;

--- a/src/simulation/elements/CRAY.cpp
+++ b/src/simulation/elements/CRAY.cpp
@@ -108,7 +108,6 @@ static int update(UPDATE_FUNC_ARGS)
 							if (!sim->IsWallBlocking(x+nxi+nxx, y+nyi+nyy, TYP(parts[i].ctype)) && (!sim->pmap[y+nyi+nyy][x+nxi+nxx] || createSpark)) { // create, also set color if it has passed through FILT
 								int nr = sim->create_part(-1, x+nxi+nxx, y+nyi+nyy, TYP(parts[i].ctype), ID(parts[i].ctype));
 								if (nr!=-1) {
-									parts[nr].flags |= parts[i].flags & FLAG_INWRDIAGONAL; // ensure INWR backwards compatibility for created parts
 									if (colored)
 										parts[nr].dcolour = colored;
 									parts[nr].temp = parts[i].temp;

--- a/src/simulation/elements/FRAY.cpp
+++ b/src/simulation/elements/FRAY.cpp
@@ -66,6 +66,9 @@ static int update(UPDATE_FUNC_ARGS)
 					continue;
 				if (TYP(r)==PT_SPRK)
 				{
+					if (parts[ID(r)].ctype == PT_INWR && rx && ry && !(parts[i].flags & FLAG_INWRDIAGONAL)) // INWR doesn't spark from diagonals
+						continue;
+					
 					for (auto nxx = 0, nyy = 0, nxi = rx*-1, nyi = ry*-1, len = 0; ; nyy+=nyi, nxx+=nxi, len++)
 					{
 						if (!(x+nxi+nxx<XRES && y+nyi+nyy<YRES && x+nxi+nxx >= 0 && y+nyi+nyy >= 0) || len>curlen)


### PR DESCRIPTION
INWR doesn't spark from diagonals. This very useful behavior was present only in DRAY, so I made ARAY, ~~CRAY~~ and FRAY share this behavior, ensuring backwards compatibility (if someone ever used INWR on diagonals).