### PR TITLE
Add new element CSTO (ctype based storage)

### DIFF
--- a/src/simulation/elements/ARAY.cpp
+++ b/src/simulation/elements/ARAY.cpp
@@ -138,11 +138,11 @@ static int update(UPDATE_FUNC_ARGS)
 								isBlackDeco = (parts[r].dcolour==0xFF000000);
 								parts[r].life = 4;
 							}
-							else if (rt == PT_STOR)
+							else if (rt == PT_STOR || rt == PT_CSTO)
 							{
 								if (parts[r].tmp)
 								{
-									//Cause STOR to release
+									//Cause STOR/CSTO to release
 									for (int ry1 = 1; ry1 >= -1; ry1--)
 									{
 										for (int rx1 = 0; rx1 >= -1 && rx1 <= 1; rx1 = -rx1 - rx1 + 1)
@@ -189,9 +189,9 @@ static int update(UPDATE_FUNC_ARGS)
 									parts[r].dcolour = 0xFF000000;
 							//this if prevents red BRAY from stopping on certain materials
 							}
-							else if (rt==PT_STOR || rt==PT_INWR || (rt==PT_SPRK && parts[r].ctype==PT_INWR) || rt==PT_ARAY || rt==PT_WIFI || rt==PT_FILT || (rt==PT_SWCH && parts[r].life>=10))
+							else if (rt==PT_STOR || rt==PT_CSTO || rt==PT_INWR || (rt==PT_SPRK && parts[r].ctype==PT_INWR) || rt==PT_ARAY || rt==PT_WIFI || rt==PT_FILT || (rt==PT_SWCH && parts[r].life>=10))
 							{
-								if (rt == PT_STOR)
+								if (rt == PT_STOR || rt == PT_CSTO)
 								{
 									parts[r].tmp = 0;
 									parts[r].life = 0;

--- a/src/simulation/elements/CSTO.cpp
+++ b/src/simulation/elements/CSTO.cpp
@@ -5,11 +5,11 @@ static int update(UPDATE_FUNC_ARGS);
 static int graphics(GRAPHICS_FUNC_ARGS);
 static bool ctypeDraw(CTYPEDRAW_FUNC_ARGS);
 
-void Element::Element_STOR()
+void Element::Element_CSTO()
 {
-	Identifier = "DEFAULT_PT_STOR";
-	Name = "STOR";
-	Colour = 0x50DFDF_rgb;
+	Identifier = "DEFAULT_PT_CSTO";
+	Name = "CSTO";
+	Colour = 0xDFDF50_rgb;
 	MenuVisible = 1;
 	MenuSection = SC_POWERED;
 	Enabled = 1;
@@ -21,7 +21,7 @@ void Element::Element_STOR()
 	Collision = 0.0f;
 	Gravity = 0.0f;
 	Diffusion = 0.00f;
-	HotAir = 0.000f	* CFDS;
+	HotAir = 0.000f * CFDS;
 	Falldown = 0;
 
 	Flammable = 0;
@@ -32,7 +32,7 @@ void Element::Element_STOR()
 	Weight = 100;
 
 	HeatConduct = 0;
-	Description = "Storage. Captures and stores a single particle. Releases when charged with PSCN, also passes to PIPE.";
+	Description = "Ctype-based Storage. If CSTO has a ctype, it will only store particles which also have that ctype.";
 
 	Properties = TYPE_SOLID | PROP_NOCTYPEDRAW;
 	CarriesTypeIn = (1U << FIELD_CTYPE) | (1U << FIELD_TMP);
@@ -53,11 +53,11 @@ void Element::Element_STOR()
 
 static int update(UPDATE_FUNC_ARGS)
 {
-	auto &sd = SimulationData::CRef();
-	auto &elements = sd.elements;
+	auto& sd = SimulationData::CRef();
+	auto& elements = sd.elements;
 	if (!sd.IsElementOrNone(parts[i].tmp))
 		parts[i].tmp = 0;
-	if(parts[i].life && !parts[i].tmp)
+	if (parts[i].life && !parts[i].tmp)
 		parts[i].life--;
 	for (auto rx = -2; rx <= 2; rx++)
 	{
@@ -65,10 +65,10 @@ static int update(UPDATE_FUNC_ARGS)
 		{
 			if (rx || ry)
 			{
-				auto r = pmap[y+ry][x+rx];
-				if ((ID(r))>=NPART || !r)
+				auto r = pmap[y + ry][x + rx];
+				if ((ID(r)) >= NPART || !r)
 					continue;
-				if (!parts[i].tmp && !parts[i].life && TYP(r)!=PT_STOR && TYP(r) != PT_CSTO && !(elements[TYP(r)].Properties&TYPE_SOLID) && (!parts[i].ctype || TYP(r)==parts[i].ctype))
+				if (!parts[i].tmp && !parts[i].life && TYP(r) != PT_STOR && TYP(r) != PT_CSTO && !(elements[TYP(r)].Properties & TYPE_SOLID) && (!parts[i].ctype || parts[ID(r)].ctype == parts[i].ctype))
 				{
 					if (TYP(r) == PT_SOAP)
 						Element_SOAP_detach(sim, ID(r));
@@ -79,14 +79,14 @@ static int update(UPDATE_FUNC_ARGS)
 					parts[i].tmp4 = parts[ID(r)].ctype;
 					sim->kill_part(ID(r));
 				}
-				if(parts[i].tmp && TYP(r)==PT_SPRK && parts[ID(r)].ctype==PT_PSCN && parts[ID(r)].life>0 && parts[ID(r)].life<4)
+				if (parts[i].tmp && TYP(r) == PT_SPRK && parts[ID(r)].ctype == PT_PSCN && parts[ID(r)].life > 0 && parts[ID(r)].life < 4)
 				{
-					for(auto ry1 = 1; ry1 >= -1; ry1--)
+					for (auto ry1 = 1; ry1 >= -1; ry1--)
 					{
-						for(auto rx1 = 0; rx1 >= -1 && rx1 <= 1; rx1 = -rx1-rx1+1) // Oscillate the X starting at 0, 1, -1, 3, -5, etc (Though stop at -1)
+						for (auto rx1 = 0; rx1 >= -1 && rx1 <= 1; rx1 = -rx1 - rx1 + 1) // Oscillate the X starting at 0, 1, -1, 3, -5, etc (Though stop at -1)
 						{
-							auto np = sim->create_part(-1,x+rx1,y+ry1,TYP(parts[i].tmp));
-							if (np!=-1)
+							auto np = sim->create_part(-1, x + rx1, y + ry1, TYP(parts[i].tmp));
+							if (np != -1)
 							{
 								parts[np].temp = parts[i].temp;
 								parts[np].life = parts[i].tmp2;
@@ -107,23 +107,24 @@ static int update(UPDATE_FUNC_ARGS)
 
 static int graphics(GRAPHICS_FUNC_ARGS)
 {
-	if(cpart->tmp){
+	if (cpart->tmp) {
 		*pixel_mode |= PMODE_GLOW;
-		*colr = 0x50;
+		*colr = 0xDF;
 		*colg = 0xDF;
-		*colb = 0xDF;
-	} else {
-		*colr = 0x20;
+		*colb = 0x50;
+	}
+	else {
+		*colr = 0xAF;
 		*colg = 0xAF;
-		*colb = 0xAF;
+		*colb = 0x20;
 	}
 	return 0;
 }
 
 static bool ctypeDraw(CTYPEDRAW_FUNC_ARGS)
 {
-	auto &sd = SimulationData::CRef();
-	auto &elements = sd.elements;
+	auto& sd = SimulationData::CRef();
+	auto& elements = sd.elements;
 	if (elements[t].Properties & TYPE_SOLID)
 	{
 		return false;

--- a/src/simulation/elements/PIPE.cpp
+++ b/src/simulation/elements/PIPE.cpp
@@ -265,9 +265,9 @@ int Element_PIPE_update(UPDATE_FUNC_ARGS)
 					transfer_part_to_pipe(parts+(ID(r)), parts+i);
 					sim->kill_part(ID(r));
 				}
-				else if (!TYP(parts[i].ctype) && TYP(r)==PT_STOR && sd.IsElement(parts[ID(r)].tmp) && (elements[parts[ID(r)].tmp].Properties & (TYPE_PART | TYPE_LIQUID | TYPE_GAS | TYPE_ENERGY)))
+				else if (!TYP(parts[i].ctype) && (TYP(r)==PT_STOR || TYP(r)==PT_CSTO) && sd.IsElement(parts[ID(r)].tmp) && (elements[parts[ID(r)].tmp].Properties & (TYPE_PART | TYPE_LIQUID | TYPE_GAS | TYPE_ENERGY)))
 				{
-					// STOR stores properties in the same places as PIPE does
+					// STOR/CSTO stores properties in the same places as PIPE does
 					transfer_pipe_to_pipe(parts+(ID(r)), parts+i, true);
 				}
 			}
@@ -429,8 +429,8 @@ static void props_pipe_to_part(const Particle *pipe, Particle *part, bool STOR)
 {
 	auto &sd = SimulationData::CRef();
 	auto &elements = sd.elements;
-	// STOR also calls this function to move particles from STOR to PRTI
-	// PIPE was changed, so now PIPE and STOR don't use the same particle storage format
+	// STOR/CSTO also calls this function to move particles from STOR/CSTO to PRTI
+	// PIPE was changed, so now PIPE and STOR/CSTO don't use the same particle storage format
 	if (STOR)
 	{
 		part->type = TYP(pipe->tmp);

--- a/src/simulation/elements/PRTI.cpp
+++ b/src/simulation/elements/PRTI.cpp
@@ -78,9 +78,9 @@ static int update(UPDATE_FUNC_ARGS)
 		if (rx || ry)
 		{
 			int r = pmap[y+ry][x+rx];
-			if (!r || TYP(r) == PT_STOR)
+			if (!r || TYP(r) == PT_STOR || TYP(r) == PT_CSTO)
 				fe = 1;
-			if (!r || (!(elements[TYP(r)].Properties & (TYPE_PART | TYPE_LIQUID | TYPE_GAS | TYPE_ENERGY)) && TYP(r)!=PT_SPRK && TYP(r)!=PT_STOR))
+			if (!r || (!(elements[TYP(r)].Properties & (TYPE_PART | TYPE_LIQUID | TYPE_GAS | TYPE_ENERGY)) && TYP(r)!=PT_SPRK && TYP(r)!=PT_STOR && TYP(r)!=PT_CSTO))
 			{
 				r = sim->photons[y+ry][x+rx];
 				if (!r)
@@ -96,7 +96,7 @@ static int update(UPDATE_FUNC_ARGS)
 			for (int nnx=0; nnx<80; nnx++)
 				if (!sim->portalp[parts[i].tmp][count][nnx].type)
 				{
-					if (TYP(r) == PT_STOR)
+					if (TYP(r) == PT_STOR || TYP(r) == PT_CSTO)
 					{
 						if (sd.IsElement(parts[ID(r)].tmp) && (elements[parts[ID(r)].tmp].Properties & (TYPE_PART | TYPE_LIQUID | TYPE_GAS | TYPE_ENERGY)))
 						{

--- a/src/simulation/elements/meson.build
+++ b/src/simulation/elements/meson.build
@@ -192,7 +192,8 @@ simulation_elem_names = [
 	'ROCK',
 	'LITH',
 	'RSST',
-	'RSSS'
+	'RSSS',
+	'CSTO'
 ]
 
 simulation_elem_src = []


### PR DESCRIPTION
### CSTO - ctype-based storage.
![image](https://github.com/user-attachments/assets/65e86d42-e07f-4d2c-8058-840450085853)
![image](https://github.com/user-attachments/assets/ab6550b4-70ba-4f41-b933-fa729820faeb)

Initially proposed by me in [this thread](https://powdertoy.co.uk/Discussions/Thread/View.html?Thread=27232) on the TPT forum.

When spawned, CSTO will operate identically to STOR. It will intake any nearby non-solid particle and then release it when sparked by PSCN. It can pass to PIPE/PPIP and PRTI just like STOR. It also store all of the target particle's properties in the exact same fields as STOR.

The main difference is that when CSTO has a ctype set (which can be done with the brush just like STOR), it will only store particles which have the same _ctype_ (as opposed to the same type like STOR does).

![image](https://github.com/user-attachments/assets/2bfedce0-237c-463c-9d12-c39284992baa)

When it is holding a particle, it glows a slightly brighter shade of yellow in the same way STOR glows a slightly brighter shade of blue.

![image](https://github.com/user-attachments/assets/85416d61-873a-47a6-a942-7d61a87f27ec)

The obvious main use of this is for separating molten metals/minerals (which all become LAVA and thus can't be separated by STOR), without needing an elaborate melt/mix/cool/drain contraption.