### PR TITLE
PSTN extension/retraction minimums using tmp3/tmp4

### DIFF
--- a/src/simulation/elements/PSTN.cpp
+++ b/src/simulation/elements/PSTN.cpp
@@ -334,7 +334,7 @@ static int MoveStack(Simulation* sim, int stackX, int stackY, int directionX, in
 			return amount;
 		}
 	} else {
-		StackData stackData = CanMoveStack(sim, stackX, stackY, directionX, directionY, maxSize, amount, retract, block, minextend, minretract);
+		StackData stackData = CanMoveStack(sim, stackX, stackY, directionX, directionY, maxSize, amount, retract, block);
 		int currentPos = stackData.pushed + stackData.spaces;
 		if (stackData.spaces>=minextend)
 		{


### PR DESCRIPTION
PSTN currently does not use tmp3 or tmp4. This change allows continued use as is, or, if tmp3 or tmp4 are changed from their default 0 values, can give users control over the minimum extension and minimum retraction distance.

Will have no effect on existing pstn, assuming they all have tmp3 and tmp4 of zero.
Will have no effect on newly drawn pstn, as the default tmp3 and tmp4 values are 0
Allows users to - using the prop tool, console, or scripts - modify the tmp3 and tmp4 values of pstn, and by doing so gain increased functionality from this already existing element.
This has been tested through a variety of test cases, and has numerous applications.