### PR TITLE
STOR can absorb radiation particles

### DIFF
--- a/src/simulation/elements/STOR.cpp
+++ b/src/simulation/elements/STOR.cpp
@@ -66,7 +66,9 @@ static int update(UPDATE_FUNC_ARGS)
 			if (rx || ry)
 			{
 				auto r = pmap[y+ry][x+rx];
-				if ((ID(r))>=NPART || !r)
+				if (!r)
+					r= sim->photons[y+ry][x+rx];
+				if (!r)
 					continue;
 				if (!parts[i].tmp && !parts[i].life && TYP(r)!=PT_STOR && !(elements[TYP(r)].Properties&TYPE_SOLID) && (!parts[i].ctype || TYP(r)==parts[i].ctype))
 				{


### PR DESCRIPTION
If stor has no ctype, or its ctype is a radiation particle, this allows it to grab radiation particles, not just liquids, gasses and powders.