### PR TITLE
Fire and Plsm create wtrv, not dstw

### DIFF
--- a/src/simulation/elements/FIRE.cpp
+++ b/src/simulation/elements/FIRE.cpp
@@ -68,7 +68,7 @@ int Element_FIRE_update(UPDATE_FUNC_ARGS)
 				parts[i].life = 0;
 			}
 			else if ((parts[i].tmp&0x3) == 3){
-				sim->part_change_type(i,x,y,PT_DSTW);
+				sim->part_change_type(i,x,y,PT_WTRV);
 				parts[i].life = 0;
 				parts[i].ctype = PT_FIRE;
 			}
@@ -78,7 +78,7 @@ int Element_FIRE_update(UPDATE_FUNC_ARGS)
 		if (parts[i].life <=1)
 		{
 			if ((parts[i].tmp&0x3) == 3){
-				sim->part_change_type(i,x,y,PT_DSTW);
+				sim->part_change_type(i,x,y,PT_WTRV);
 				parts[i].life = 0;
 				parts[i].ctype = PT_FIRE;
 			}


### PR DESCRIPTION
When combusting hygn and oxyg together, it creates fire or plsm that will eventually turn into dstw. If you have a 3x3 of such particles, and the center particle turns into dstw, it will delete the other 8 particles before it evaporates, as it is usually at a high temperature. This would change that, starting the water out as wtrv, and, in the rarer case where the fire/plsm was below the boiling point, only then would a state change be needed. In most other cases, it will keep fire-created superheated steam from killing superheatedsteam-creating fire.