### PR TITLE
Add Gasoline (GSOL and GSLV)

### DIFF
--- a/src/simulation/elements/GSLV.cpp
+++ b/src/simulation/elements/GSLV.cpp
@@ -17,7 +17,7 @@ void Element::Element_GSLV()
 	Gravity = 0.1f;
 	Diffusion = 1.0f;
 	HotAir = 0.0f	* CFDS;
-	Falldown = 1;
+	Falldown = 0;
 
 	Flammable = 1000;
 	Explosive = 0;
@@ -33,7 +33,7 @@ void Element::Element_GSLV()
 
 	LowPressure = IPL;
 	LowPressureTransition = NT;
-	HighPressure = 10.0f;
+	HighPressure = 7.0f;
 	HighPressureTransition = PT_FIRE;
 	LowTemperature = ITL;
 	LowTemperatureTransition = NT;

--- a/src/simulation/elements/GSLV.cpp
+++ b/src/simulation/elements/GSLV.cpp
@@ -1,0 +1,42 @@
+#include "simulation/ElementCommon.h"
+
+void Element::Element_GSLV()
+{
+	Identifier = "DEFAULT_PT_GSLV";
+	Name = "GSLV";
+	Colour = 0x62631E_rgb;
+	MenuVisible = 1;
+	MenuSection = SC_GAS;
+	Enabled = 1;
+
+	Advection = 2.0f;
+	AirDrag = 0.00f * CFDS;
+	AirLoss = 0.99f;
+	Loss = 0.30f;
+	Collision = -0.1f;
+	Gravity = 0.1f;
+	Diffusion = 1.0f;
+	HotAir = 0.0f	* CFDS;
+	Falldown = 1;
+
+	Flammable = 1000;
+	Explosive = 0;
+	Meltable = 0;
+	Hardness = 1;
+
+	Weight = 1;
+
+	HeatConduct = 42;
+	Description = "Gasoline vapors. Highly flammable.";
+
+	Properties = TYPE_GAS;
+
+	LowPressure = IPL;
+	LowPressureTransition = NT;
+	HighPressure = 10.0f;
+	HighPressureTransition = PT_FIRE;
+	LowTemperature = ITL;
+	LowTemperatureTransition = NT;
+	HighTemperature = 375.0f;
+	HighTemperatureTransition = PT_FIRE;
+}

--- a/src/simulation/elements/GSOL.cpp
+++ b/src/simulation/elements/GSOL.cpp
@@ -29,13 +29,13 @@ void Element::Element_GSOL()
 	Weight = 7;
 
 	HeatConduct = 42;
-	Description = "Gasoline. Slowly turns into flammable vapors.";
+	Description = "Gasoline. Slowly turns into flammable vapors. Evaporates less when cold.";
 
 	Properties = TYPE_LIQUID;
 
 	LowPressure = IPL;
 	LowPressureTransition = NT;
-	HighPressure = 10.0f;
+	HighPressure = 7.0f;
 	HighPressureTransition = PT_FIRE;
 	LowTemperature = ITL;
 	LowTemperatureTransition = NT;
@@ -47,10 +47,11 @@ void Element::Element_GSOL()
 
 static int update(UPDATE_FUNC_ARGS)
 {
-	if (sim->rng.chance(1, 200) && !pmap[y-1][x])
+	if (parts[i].temp <= 375.0f ? sim->rng.chance((int)parts[i].temp, 2000000) : sim->rng.chance(375, 2000000))
 	{
 		sim->create_part(i, x, y, PT_GSLV);
-        return -1;
+		return -1;
 	}
+
 	return 0;
 }

--- a/src/simulation/elements/GSOL.cpp
+++ b/src/simulation/elements/GSOL.cpp
@@ -47,7 +47,7 @@ void Element::Element_GSOL()
 
 static int update(UPDATE_FUNC_ARGS)
 {
-	if (parts[i].temp <= 375.0f ? sim->rng.chance((int)parts[i].temp, 2000000) : sim->rng.chance(375, 2000000))
+	if (sim->rng.chance(std::min((int)parts[i].temp, 375), 2000000))
 	{
 		sim->create_part(i, x, y, PT_GSLV);
 		return -1;

--- a/src/simulation/elements/GSOL.cpp
+++ b/src/simulation/elements/GSOL.cpp
@@ -1,0 +1,56 @@
+#include "simulation/ElementCommon.h"
+
+static int update(UPDATE_FUNC_ARGS);
+
+void Element::Element_GSOL()
+{
+	Identifier = "DEFAULT_PT_GSOL";
+	Name = "GSOL";
+	Colour = 0x969530_rgb;
+	MenuVisible = 1;
+	MenuSection = SC_LIQUID;
+	Enabled = 1;
+
+	Advection = 1.0f;
+	AirDrag = 0.01f * CFDS;
+	AirLoss = 0.98f;
+	Loss = 0.95f;
+	Collision = 0.0f;
+	Gravity = 0.1f;
+	Diffusion = 0.0f;
+	HotAir = 0.0f	* CFDS;
+	Falldown = 2;
+
+	Flammable = 10;
+	Explosive = 0;
+	Meltable = 0;
+	Hardness = 5;
+
+	Weight = 7;
+
+	HeatConduct = 42;
+	Description = "Gasoline. Slowly turns into flammable vapors.";
+
+	Properties = TYPE_LIQUID;
+
+	LowPressure = IPL;
+	LowPressureTransition = NT;
+	HighPressure = 10.0f;
+	HighPressureTransition = PT_FIRE;
+	LowTemperature = ITL;
+	LowTemperatureTransition = NT;
+	HighTemperature = 375.0f;
+	HighTemperatureTransition = PT_FIRE;
+
+    Update = &update;
+}
+
+static int update(UPDATE_FUNC_ARGS)
+{
+	if (sim->rng.chance(1, 200) && !pmap[y-1][x])
+	{
+		sim->create_part(i, x, y, PT_GSLV);
+        return -1;
+	}
+	return 0;
+}

--- a/src/simulation/elements/STKM.cpp
+++ b/src/simulation/elements/STKM.cpp
@@ -709,25 +709,25 @@ void Element_STKM_init_legs(Simulation * sim, playerst *playerp, int i)
 	x = (int)(sim->parts[i].x+0.5f);
 	y = (int)(sim->parts[i].y+0.5f);
 
-	playerp->legs[0] = float(x+2);
-	playerp->legs[1] = float(y+5);
-	playerp->legs[2] = float(x+2);
-	playerp->legs[3] = float(y+5);
+	playerp->legs[0] = float(x-1);
+	playerp->legs[1] = float(y+6);
+	playerp->legs[2] = float(x-1);
+	playerp->legs[3] = float(y+6);
 
-	playerp->legs[4] = float(x+2);
-	playerp->legs[5] = float(y+10);
-	playerp->legs[6] = float(x+2);
-	playerp->legs[7] = float(y+10);
+	playerp->legs[4] = float(x-3);
+	playerp->legs[5] = float(y+12);
+	playerp->legs[6] = float(x-3);
+	playerp->legs[7] = float(y+12);
 
-	playerp->legs[8] = float(x-2);
-	playerp->legs[9] = float(y+5);
-	playerp->legs[10] = float(x-2);
-	playerp->legs[11] = float(y+5);
+	playerp->legs[8] = float(x+1);
+	playerp->legs[9] = float(y+6);
+	playerp->legs[10] = float(x+1);
+	playerp->legs[11] = float(y+6);
 
-	playerp->legs[12] = float(x-2);
-	playerp->legs[13] = float(y+10);
-	playerp->legs[14] = float(x-2);
-	playerp->legs[15] = float(y+10);
+	playerp->legs[12] = float(x+3);
+	playerp->legs[13] = float(y+12);
+	playerp->legs[14] = float(x+3);
+	playerp->legs[15] = float(y+12);
 
 	for (int i = 0; i < 8; i++)
 		playerp->accs[i] = 0;

--- a/src/simulation/elements/meson.build
+++ b/src/simulation/elements/meson.build
@@ -58,6 +58,8 @@ simulation_elem_names = [
 	'SWCH',
 	'SMKE',
 	'DESL',
+	'GSOL',
+	'GSLV',
 	'COAL',
 	'LO2',
 	'O2',


### PR DESCRIPTION
Add Gasoline (GSOL) and gasoline vapors (GSLV)

GSOL is like DESL except it has a higher combustion pressure (2 units higher than DESL), lower density and it is more flammable. It also slowly turns into GSLV (the rate at which this state change occurs is determined by the temperature. Higher = more vapors).

GSLV is a highly flammable heavy gas that is spawned when GSOL evaporates, as mentioned above.

I did this because the only (realistic) fuel element for engines was DESL. DESL + O2 doesn't really mix well and it doesnt make a much of a difference compared to DESL without O2. Adding O2 to GSOL also doesnt really help in any way, but GSLV + O2 creates a pretty homogenous mixture that combusts better.

These elements could be used to create more realistic engines with carburetors (because of the GSLV + O2 mixture and in real life engines gasoline is vaporized before entering the engine so theres no need to worry about GSOL being in places where it shouldn't be if the engine is built properly).