### PR TITLE
Fog/Rime can absorb gas to become acidic, condense to acid

### DIFF
--- a/src/simulation/Simulation.cpp
+++ b/src/simulation/Simulation.cpp
@@ -2496,7 +2496,11 @@ void Simulation::UpdateParticles(int start, int end)
 						else if (t == PT_RIME)
 						{
 							if (parts[i].tmp > 5)
+							{
 								t = PT_ACID;
+								parts[i].life = 25 + 5 * parts[i].tmp;
+								parts[i].tmp = 0;
+							}
 							else
 								t = PT_WATR;
 						}
@@ -2573,7 +2577,7 @@ void Simulation::UpdateParticles(int start, int end)
 					{
 						if (t==PT_ICEI || t==PT_LAVA || t==PT_SNOW)
 							parts[i].ctype = parts[i].type;
-						if (!(t==PT_ICEI && parts[i].ctype==PT_FRZW))
+						if (!(t==PT_ICEI && parts[i].ctype==PT_FRZW) && t!=PT_ACID)
 							parts[i].life = 0;
 						if (t == PT_FIRE)
 						{
@@ -2606,11 +2610,6 @@ void Simulation::UpdateParticles(int start, int end)
 							else if (parts[i].ctype == PT_PQRT) parts[i].ctype = PT_QRTZ;
 							else if (parts[i].ctype == PT_LITH && parts[i].tmp2 > 3) parts[i].ctype = PT_GLAS;
 							parts[i].life = rng.between(240, 359);
-						}
-						if (t == PT_ACID)
-						{
-							parts[i].life = 25 + 5 * parts[i].tmp;
-							parts[i].tmp = 0;
 						}
 						transitionOccurred = true;
 					}

--- a/src/simulation/Simulation.cpp
+++ b/src/simulation/Simulation.cpp
@@ -2493,14 +2493,12 @@ void Simulation::UpdateParticles(int start, int end)
 							else
 								t = PT_LAVA;
 						}
-						else if (t == PT_FOG || t == PT_RIME)
+						else if (t == PT_RIME)
 						{
-							if (parts[i].tmp > 0)
+							if (parts[i].tmp > 5)
 							{
 								t = PT_ACID;
 							}
-							else if (t == PT_FOG)
-								t = PT_WTRV;
 							else
 								t = PT_WATR;
 						}
@@ -2613,7 +2611,7 @@ void Simulation::UpdateParticles(int start, int end)
 						}
 						if (t == PT_ACID)
 						{
-							parts[i].life = 50 + 5 * parts[i].tmp;
+							parts[i].life = 25 + 5 * parts[i].tmp;
 							parts[i].tmp = 0;
 						}
 						transitionOccurred = true;

--- a/src/simulation/Simulation.cpp
+++ b/src/simulation/Simulation.cpp
@@ -2493,6 +2493,17 @@ void Simulation::UpdateParticles(int start, int end)
 							else
 								t = PT_LAVA;
 						}
+						else if (t == PT_FOG || t == PT_RIME)
+						{
+							if (parts[i].tmp > 0)
+							{
+								t = PT_ACID;
+							}
+							else if (t == PT_FOG)
+								t = PT_WTRV;
+							else
+								t = PT_WATR;
+						}
 						else
 							s = 0;
 					}
@@ -2599,6 +2610,11 @@ void Simulation::UpdateParticles(int start, int end)
 							else if (parts[i].ctype == PT_PQRT) parts[i].ctype = PT_QRTZ;
 							else if (parts[i].ctype == PT_LITH && parts[i].tmp2 > 3) parts[i].ctype = PT_GLAS;
 							parts[i].life = rng.between(240, 359);
+						}
+						if (t == PT_ACID)
+						{
+							parts[i].life = 50 + 5 * parts[i].tmp;
+							parts[i].tmp = 0;
 						}
 						transitionOccurred = true;
 					}

--- a/src/simulation/Simulation.cpp
+++ b/src/simulation/Simulation.cpp
@@ -2496,9 +2496,7 @@ void Simulation::UpdateParticles(int start, int end)
 						else if (t == PT_RIME)
 						{
 							if (parts[i].tmp > 5)
-							{
 								t = PT_ACID;
-							}
 							else
 								t = PT_WATR;
 						}

--- a/src/simulation/Simulation.cpp
+++ b/src/simulation/Simulation.cpp
@@ -2502,7 +2502,9 @@ void Simulation::UpdateParticles(int start, int end)
 								parts[i].tmp = 0;
 							}
 							else
+							{
 								t = PT_WATR;
+							}
 						}
 						else
 							s = 0;

--- a/src/simulation/elements/ACID.cpp
+++ b/src/simulation/elements/ACID.cpp
@@ -82,7 +82,7 @@ static int update(UPDATE_FUNC_ARGS)
 							sim->kill_part(ID(r));
 						}
 					}
-					else if (rt != PT_CLNE && rt != PT_PCLN && ((rt != PT_FOG && rt != PT_RIME) || parts[ID(r)].tmp == 0) && parts[i].life > 50 && sim->rng.chance(elements[rt].Hardness, 1000))
+					else if (rt != PT_CLNE && rt != PT_PCLN && ((rt != PT_FOG && rt != PT_RIME) || parts[ID(r)].tmp <= 5) && parts[i].life > 50 && sim->rng.chance(elements[rt].Hardness, 1000))
 					{
 						if (sim->parts_avg(i, ID(r),PT_GLAS)!= PT_GLAS)//GLAS protects stuff from acid
 						{

--- a/src/simulation/elements/ACID.cpp
+++ b/src/simulation/elements/ACID.cpp
@@ -82,7 +82,7 @@ static int update(UPDATE_FUNC_ARGS)
 							sim->kill_part(ID(r));
 						}
 					}
-					else if (rt != PT_CLNE && rt != PT_PCLN && parts[i].life > 50 && sim->rng.chance(elements[rt].Hardness, 1000))
+					else if (rt != PT_CLNE && rt != PT_PCLN && ((rt != PT_FOG && rt != PT_RIME) || parts[ID(r)].tmp == 0) && parts[i].life > 50 && sim->rng.chance(elements[rt].Hardness, 1000))
 					{
 						if (sim->parts_avg(i, ID(r),PT_GLAS)!= PT_GLAS)//GLAS protects stuff from acid
 						{

--- a/src/simulation/elements/CAUS.cpp
+++ b/src/simulation/elements/CAUS.cpp
@@ -72,7 +72,7 @@ static int update(UPDATE_FUNC_ARGS)
 				}
 				else if (TYP(r) != PT_ACID && TYP(r) != PT_CAUS && TYP(r) != PT_RFRG && TYP(r) != PT_RFGL)
 				{
-					if ((TYP(r) != PT_CLNE && TYP(r) != PT_PCLN && sim->rng.chance(elements[TYP(r)].Hardness, 1000)) && parts[i].life >= 50)
+					if ((TYP(r) != PT_CLNE && TYP(r) != PT_PCLN && ((TYP(r) != PT_FOG && TYP(r) != PT_RIME) || parts[ID(r)].tmp == 0) && sim->rng.chance(elements[TYP(r)].Hardness, 1000)) && parts[i].life > 50)
 					{
 						// GLAS protects stuff from acid
 						if (sim->parts_avg(i, ID(r),PT_GLAS) != PT_GLAS)

--- a/src/simulation/elements/CAUS.cpp
+++ b/src/simulation/elements/CAUS.cpp
@@ -72,7 +72,7 @@ static int update(UPDATE_FUNC_ARGS)
 				}
 				else if (TYP(r) != PT_ACID && TYP(r) != PT_CAUS && TYP(r) != PT_RFRG && TYP(r) != PT_RFGL)
 				{
-					if ((TYP(r) != PT_CLNE && TYP(r) != PT_PCLN && ((TYP(r) != PT_FOG && TYP(r) != PT_RIME) || parts[ID(r)].tmp == 0) && sim->rng.chance(elements[TYP(r)].Hardness, 1000)) && parts[i].life > 50)
+					if ((TYP(r) != PT_CLNE && TYP(r) != PT_PCLN && ((TYP(r) != PT_FOG && TYP(r) != PT_RIME) || parts[ID(r)].tmp <= 5) && sim->rng.chance(elements[TYP(r)].Hardness, 1000)) && parts[i].life > 50)
 					{
 						// GLAS protects stuff from acid
 						if (sim->parts_avg(i, ID(r),PT_GLAS) != PT_GLAS)

--- a/src/simulation/elements/FOG.cpp
+++ b/src/simulation/elements/FOG.cpp
@@ -41,7 +41,7 @@ void Element::Element_FOG()
 	LowTemperature = ITL;
 	LowTemperatureTransition = NT;
 	HighTemperature = 373.15f;
-	HighTemperatureTransition = ST;
+	HighTemperatureTransition = PT_WTRV;
 
 	Update = &update;
 }
@@ -67,7 +67,7 @@ static int update(UPDATE_FUNC_ARGS)
 				{
 					parts[i].life += sim->rng.between(0, 19);
 				}
-				if (TYP(r) == PT_GAS && parts[i].tmp < 5)
+				if (TYP(r) == PT_GAS && parts[i].tmp < 10)
 				{
 					sim->kill_part(ID(r));
 					parts[i].tmp++;

--- a/src/simulation/elements/FOG.cpp
+++ b/src/simulation/elements/FOG.cpp
@@ -41,7 +41,7 @@ void Element::Element_FOG()
 	LowTemperature = ITL;
 	LowTemperatureTransition = NT;
 	HighTemperature = 373.15f;
-	HighTemperatureTransition = PT_WTRV;
+	HighTemperatureTransition = ST;
 
 	Update = &update;
 }
@@ -66,6 +66,11 @@ static int update(UPDATE_FUNC_ARGS)
 				if (TYP(r)==PT_SPRK)
 				{
 					parts[i].life += sim->rng.between(0, 19);
+				}
+				if (TYP(r) == PT_GAS && parts[i].tmp < 5)
+				{
+					sim->kill_part(ID(r));
+					parts[i].tmp++;
 				}
 			}
 		}

--- a/src/simulation/elements/RIME.cpp
+++ b/src/simulation/elements/RIME.cpp
@@ -41,7 +41,7 @@ void Element::Element_RIME()
 	LowTemperature = ITL;
 	LowTemperatureTransition = NT;
 	HighTemperature = 273.15f;
-	HighTemperatureTransition = PT_WATR;
+	HighTemperatureTransition = ST;
 
 	Update = &update;
 }
@@ -61,6 +61,11 @@ static int update(UPDATE_FUNC_ARGS)
 				{
 					sim->part_change_type(i,x,y,PT_FOG);
 					parts[i].life = sim->rng.between(60, 119);
+				}
+				else if (TYP(r) == PT_GAS && parts[i].tmp < 5)
+				{
+					sim->kill_part(ID(r));
+					parts[i].tmp++;
 				}
 				else if (TYP(r)==PT_FOG&&parts[ID(r)].life>0)
 				{

--- a/src/simulation/elements/RIME.cpp
+++ b/src/simulation/elements/RIME.cpp
@@ -62,7 +62,7 @@ static int update(UPDATE_FUNC_ARGS)
 					sim->part_change_type(i,x,y,PT_FOG);
 					parts[i].life = sim->rng.between(60, 119);
 				}
-				else if (TYP(r) == PT_GAS && parts[i].tmp < 5)
+				else if (TYP(r) == PT_GAS && parts[i].tmp < 10)
 				{
 					sim->kill_part(ID(r));
 					parts[i].tmp++;


### PR DESCRIPTION
Fog and Rime can increase their acidity (tmp) from 0 to 5. At nonzero tmp, their high temperature transition is replaced with acid instead of watr/wtrv. The acid produced has a life of 50+5*tmp, so every absorbed gas allows the created acid to dissolve 5 elements. Fog and Rime of nonzero acidity can no longer be dissolved by acid or caus.

