### PR TITLE
src/lua/LuaSocketDefault.cpp: add missing <climits> include

### DIFF
--- a/src/lua/LuaSocketDefault.cpp
+++ b/src/lua/LuaSocketDefault.cpp
@@ -2,6 +2,7 @@
 #include "Misc.h"
 #include <stdint.h>
 #include <algorithm>
+#include <climits>
 #include <sys/time.h>
 #include <time.h>
 


### PR DESCRIPTION
Without the change the build fails on upcoming `gcc-16` as:

    ../src/lua/LuaSocketDefault.cpp: In function 'void LuaSocket::Timeout(double)':
    ../src/lua/LuaSocketDefault.cpp:21:31: error: 'INT_MAX' was not declared in this scope
       21 |                 if (timeout > INT_MAX) timeout = INT_MAX;
          |                               ^~~~~~~
    ../src/lua/LuaSocketDefault.cpp:6:1: note: 'INT_MAX' is defined in header '<climits>'; this is probably fixable by adding '#include <climits>'
        5 | #include <sys/time.h>
      +++ |+#include <climits>
        6 | #include <time.h>