### PR TITLE
Shift base color change up 1 life for balance

### DIFF
--- a/src/simulation/elements/BASE.cpp
+++ b/src/simulation/elements/BASE.cpp
@@ -214,19 +214,19 @@ static int graphics(GRAPHICS_FUNC_ARGS)
 {
 	int s = cpart->life;
 
-	if (s < 25)
+	if (s <= 25)
 	{
 		*colr = 0x33;
 		*colg = 0x4C;
 		*colb = 0xD8;
 	}
-	else if (s < 50)
+	else if (s <= 50)
 	{
 		*colr = 0x58;
 		*colg = 0x83;
 		*colb = 0xE8;
 	}
-	else if (s < 75)
+	else if (s <= 75)
 	{
 		*colr = 0x7D;
 		*colg = 0xBA;


### PR DESCRIPTION
Current code is written such that life=[1,24] is one color, life=[25,49] is a different color, life=[50,74] is a third color and life=[75,100] is a fourth, final color. This means that the color bands span 24,25,25,26 life. 

More than that, base is spawned at life=75, and shows no color change when concentrating. If implemented, when spawned at 75 life, concentration of just 1 life will cause a color change, giving the user a nice visual cue. 