### PR TITLE
Improve and standardize Bizr.cpp's deco blending functions

### DIFF
--- a/src/simulation/elements/BIZR.cpp
+++ b/src/simulation/elements/BIZR.cpp
@@ -47,6 +47,8 @@ void Element::Element_BIZR()
 	Graphics = &Element_BIZR_graphics;
 }
 
+constexpr float BLEND = 21.0f;
+
 int Element_BIZR_update(UPDATE_FUNC_ARGS)
 {
 	if(parts[i].dcolour)
@@ -62,20 +64,20 @@ int Element_BIZR_update(UPDATE_FUNC_ARGS)
 						continue;
 					if (TYP(r)!=PT_BIZR && TYP(r)!=PT_BIZRG  && TYP(r)!=PT_BIZRS)
 					{
-						auto tr = float((parts[ID(r)].dcolour>>16)&0xFF);
-						auto tg = float((parts[ID(r)].dcolour>>8)&0xFF);
-						auto tb = float((parts[ID(r)].dcolour)&0xFF);
-						auto ta = float((parts[ID(r)].dcolour>>24)&0xFF);
+						int tr = (parts[ID(r)].dcolour>>16)&0xFF;
+						int tg = (parts[ID(r)].dcolour>>8)&0xFF;
+						int tb = (parts[ID(r)].dcolour)&0xFF;
+						int ta = (parts[ID(r)].dcolour>>24)&0xFF;
 
-						auto mr = float((parts[i].dcolour>>16)&0xFF);
-						auto mg = float((parts[i].dcolour>>8)&0xFF);
-						auto mb = float((parts[i].dcolour)&0xFF);
-						auto ma = float((parts[i].dcolour>>24)&0xFF);
+						int mr = (parts[i].dcolour>>16)&0xFF;
+						int mg = (parts[i].dcolour>>8)&0xFF;
+						int mb = (parts[i].dcolour)&0xFF;
+						int ma = (parts[i].dcolour>>24)&0xFF;
 
-						auto nr = int(tr + ((mr > tr) - (mr < tr)) + static_cast<int>(std::round((mr - tr) / 21.0)));
-						auto ng = int(tg + ((mg > tg) - (mg < tg)) + static_cast<int>(std::round((mg - tg) / 21.0)));
-						auto nb = int(tb + ((mb > tb) - (mb < tb)) + static_cast<int>(std::round((mb - tb) / 21.0)));
-						auto na = int(ta + ((ma > ta) - (ma < ta)) + static_cast<int>(std::round((ma - ta) / 21.0)));
+						int nr = tr + ((mr > tr) - (mr < tr)) + int(std::round((mr - tr) / BLEND));
+						int ng = tg + ((mg > tg) - (mg < tg)) + int(std::round((mg - tg) / BLEND));
+						int nb = tb + ((mb > tb) - (mb < tb)) + int(std::round((mb - tb) / BLEND));
+						int na = ta + ((ma > ta) - (ma < ta)) + int(std::round((ma - ta) / BLEND));
 
 						parts[ID(r)].dcolour = nr<<16 | ng<<8 | nb | na<<24;
 					}

--- a/src/simulation/elements/BIZR.cpp
+++ b/src/simulation/elements/BIZR.cpp
@@ -47,8 +47,6 @@ void Element::Element_BIZR()
 	Graphics = &Element_BIZR_graphics;
 }
 
-constexpr float BLEND = 0.95f;
-
 int Element_BIZR_update(UPDATE_FUNC_ARGS)
 {
 	if(parts[i].dcolour)
@@ -74,10 +72,10 @@ int Element_BIZR_update(UPDATE_FUNC_ARGS)
 						auto mb = float((parts[i].dcolour)&0xFF);
 						auto ma = float((parts[i].dcolour>>24)&0xFF);
 
-						auto nr = int((tr*BLEND) + (mr*(1 - BLEND)));
-						auto ng = int((tg*BLEND) + (mg*(1 - BLEND)));
-						auto nb = int((tb*BLEND) + (mb*(1 - BLEND)));
-						auto na = int((ta*BLEND) + (ma*(1 - BLEND)));
+						auto nr = int(tr + ((mr > tr) - (mr < tr)) + static_cast<int>(std::round((mr - tr) / 21.0)));
+						auto ng = int(tg + ((mg > tg) - (mg < tg)) + static_cast<int>(std::round((mg - tg) / 21.0)));
+						auto nb = int(tb + ((mb > tb) - (mb < tb)) + static_cast<int>(std::round((mb - tb) / 21.0)));
+						auto na = int(ta + ((ma > ta) - (ma < ta)) + static_cast<int>(std::round((ma - ta) / 21.0)));
 
 						parts[ID(r)].dcolour = nr<<16 | ng<<8 | nb | na<<24;
 					}


### PR DESCRIPTION
Bizr, Bizg and Bizs are the only three elements that can alter an element's decoration layer towards a certain color (as opposed to soap, which can only return it to its original color).

All three of these elements rely on the dcolor blending function of bizr.cpp. So if you want part of your save to decorate something to look a certain way, or be a certain color, but don't want to manually apply the decoration yourself, you have to rely on bizr slowly changing the color of elements around it to match its own.

But while the original dcolor blending code works decently, its implementation is such that r, g, b and a values cannot be risen above 236, even when the bizr's respective value is 255. The same is not true in the reverse case, a bizr of r=0 will have no trouble lowering the r value of any nearby elements to 0 as well. 

The favoritism towards lowering the target values to meet those of bizr, as compared to raising the target values to meet bizr, is due to the usage of int(, which rounds down to the nearest integer. 0.95 and 254.95 are lowered to 0 and 254, so a mere change of 0.01 is needed to decrease the value, while an increase of at least one is needed to increase it. 

The old formula got most of the job done, but the new formula i have created causes deco color to change at the same rate regardless of if it is increasing or decreasing, and also does not have the same blindspot.

Replacing int with floor, ciel, or even round alone would still leave dead areas at the edges of the spectrum. As such, the new formula has a base change for each value by moving it 1 towards the bizr, and then moving it an additional distance calculated by rounding the difference in values by 21.

The constant 21 was arrived at as a compromise. using a constant of 20 would be analogous to the blend=0.95 used in the old code, where every 20 difference would cause 1 movement. But as a constant movement of 1 is being added to this, the number was increased to 21. If increased further, the decoration process from 0->255 and 255->0 will be closer to the old version's 0->236 and 255->0, but will have less of a dependence on the difference in value between bizr and the target (making it less a blend and more a shift)

The result is that the old and new formulas have the same behavior for the first 18 frames when decreasing values. Also, the reduction in value of the target deco in the decreasing series is equal now to the increase in value of the target deco in the increasing series, showing equal rates of change dependent solely on the difference in values between target and bizr. When compared to the old code, there is approximately a 13% increase in speed when comparing old[0->236] and old[255->0] with new[0->255] and new[255->0].

TLDR: I tweaked the blend formula, now it works equally well in both directions, allows for a complete blending of color given time, and is about the same speed as the old way.

Thank you for coming to my TPT talk. Sorry if i rambled. -jm211