### PR TITLE
Terminate Boyl.cpp update function upon transmuting boyl

### DIFF
--- a/src/simulation/elements/BOYL.cpp
+++ b/src/simulation/elements/BOYL.cpp
@@ -82,6 +82,7 @@ static int update(UPDATE_FUNC_ARGS)
 						sim->kill_part(ID(r));
 						sim->part_change_type(i,x,y,PT_WATR);
 						sim->pv[y/CELL][x/CELL] += 4.0;
+						return 1;
 					}
 				}
 			}


### PR DESCRIPTION
Boyl's code before this fix would allow a boyl to delete and oxyg, become watr, and then delete up to 7 additional (assuming no stacking) o2. This simply adds a return 1;, halting the update function for boyl (since it is no longer boyl).

TLDR: prohibits boyl that has become watr from performing more boyl update reactions.