### PR TITLE
Allow LITH to discharge to active SWCH

### DIFF
--- a/src/simulation/elements/LITH.cpp
+++ b/src/simulation/elements/LITH.cpp
@@ -163,6 +163,20 @@ static int update(UPDATE_FUNC_ARGS)
 						discharged = true;
 					}
 					break;
+				
+				case PT_SWCH:
+					if (pavg == PT_INSL || pavg == PT_RSSS)
+					{
+						break;
+					}
+					if (neighbor.life == 10 && storedEnergy > 0 && !burnTimer)
+					{
+						sim->part_change_type(ID(neighborData), x + rx, y + ry, PT_SPRK);
+						neighbor.life = 4;
+						neighbor.ctype = PT_SWCH;
+						discharged = true;
+					}
+					break;
 
 				case PT_FIRE:
 					if (self.temp > 440.f && sim->rng.chance(1, 40) && hydrogenationFactor < 6)


### PR DESCRIPTION
A problem I have had with LITH is that you have to use complicated methods to stop it from discharging, like using PSTN to move NSCN away from it. Letting it discharge to active SWCH should make it simple to change when you want it to discharge or not.