### PR TITLE
Add a sane behaviour for DRAY when copying players and fighters

### DIFF
--- a/src/graphics/Renderer.cpp
+++ b/src/graphics/Renderer.cpp
@@ -565,7 +565,9 @@ void Renderer::render_parts()
 						legg = colg;
 						legb = colb;
 					}
-					else if (t==PT_STKM2)
+					else if (t==PT_STKM2 
+                            || (
+                                t==PT_FIGH && (sim->parts[i].tmp2&Element_FIGH_stk2_mask)))
 					{
 						legr = 100;
 						legg = 100;
@@ -589,7 +591,7 @@ void Renderer::render_parts()
 					}
 
 					//head
-					if(t==PT_FIGH)
+					if(t==PT_FIGH && !(sim->parts[i].tmp2&Element_FIGH_square_head_mask))
 					{
 						DrawLine({ nx, ny+2 }, { nx+2, ny }, RGB(colr, colg, colb));
 						DrawLine({ nx+2, ny }, { nx, ny-2 }, RGB(colr, colg, colb));

--- a/src/simulation/Stickman.h
+++ b/src/simulation/Stickman.h
@@ -14,3 +14,8 @@ struct playerst
 	bool fan;
 	int spawnID;         //id of the SPWN particle that spawns it
 };
+
+
+static const int Element_FIGH_moves_mask = 1; // 0 - unseen, 1 - seen
+static const int Element_FIGH_square_head_mask = 2; // 0x0 - default, 0x2 - STKM-aligned, square head
+static const int Element_FIGH_stk2_mask = 4; // 0x0 - default, 0x2 - STKM-aligned, square head

--- a/src/simulation/elements/DRAY.cpp
+++ b/src/simulation/elements/DRAY.cpp
@@ -143,6 +143,10 @@ static int update(UPDATE_FUNC_ARGS)
 									sim->kill_part(ID(pmap[yCopyTo][xCopyTo]));
 							}
 						}
+                        
+                        // No cloning people 
+                        if (type == PT_STKM || type == PT_STKM2) type = PT_FIGH;
+
 						if (type == PT_SPRK) // spark hack
 							p = sim->create_part(-1, xCopyTo, yCopyTo, PT_METL);
 						else if (type)
@@ -150,12 +154,20 @@ static int update(UPDATE_FUNC_ARGS)
 						else
 							continue;
 
+
 						// if new particle was created successfully
 						if (p >= 0)
 						{
 							if (type == PT_SPRK) // spark hack
 								sim->part_change_type(p, xCopyTo, yCopyTo, PT_SPRK);
-							if (isEnergy)
+							if (type == PT_FIGH) { // does not like the easy appraoch
+                                const auto& other = parts[ID(pmap[yCurrent][xCurrent])];
+                                parts[p].ctype = other.ctype;
+                                parts[p].life = other.life;
+                                // do not copy tmp -- it dhould be unique
+                                parts[p].tmp2 = other.tmp2;
+                            } else 
+                                if (isEnergy)
 								parts[p] = parts[ID(sim->photons[yCurrent][xCurrent])];
 							else
 								parts[p] = parts[ID(pmap[yCurrent][xCurrent])];

--- a/src/simulation/elements/DRAY.cpp
+++ b/src/simulation/elements/DRAY.cpp
@@ -174,26 +174,6 @@ static int update(UPDATE_FUNC_ARGS)
                                     parts[p].tmp2 = other.tmp2;
                                 }
 
-//                                playerst& new_figh = sim->fighters[parts[p].tmp];
-//                                const playerst *cplayer = nullptr;
-//                                if(type==PT_STKM)
-//                                    cplayer = &sim->player;
-//                                else if(type==PT_STKM2)
-//                                    cplayer = &sim->player2;
-//                                else if (type==PT_FIGH && sim->parts[i].tmp >= 0 && other.tmp < MAX_FIGHTERS)
-//                                    cplayer = &sim->fighters[(unsigned char)other.tmp];
-//
-//                                int dx = xCopyTo - x;
-//                                int dy = yCopyTo - y;
-//
-//                                if (cplayer) {
-//                                    printf("legs\t old\t new\n");                                      
-//                                    for (int i=0; i<8; i++){
-//                                        new_figh.legs[i*2] = cplayer->legs[i*2] + dx;
-//                                        new_figh.legs[i*2+1] = cplayer->legs[i*2+1] + dy;
-//                                        new_figh.accs[i] = cplayer->accs[i];   
-//                                    }
-//                                }
                             } else 
                                 if (isEnergy)
 								parts[p] = parts[ID(sim->photons[yCurrent][xCurrent])];

--- a/src/simulation/elements/DRAY.cpp
+++ b/src/simulation/elements/DRAY.cpp
@@ -144,11 +144,11 @@ static int update(UPDATE_FUNC_ARGS)
 							}
 						}
                         
-                        // No cloning people 
-                        if (type == PT_STKM || type == PT_STKM2) type = PT_FIGH;
 
 						if (type == PT_SPRK) // spark hack
 							p = sim->create_part(-1, xCopyTo, yCopyTo, PT_METL);
+                        else if (type == PT_STKM || type == PT_STKM2) // cannot be cloned correctly
+							p = sim->create_part(-1, xCopyTo, yCopyTo, PT_FIGH);
 						else if (type)
 							p = sim->create_part(-1, xCopyTo, yCopyTo, type);
 						else
@@ -160,12 +160,40 @@ static int update(UPDATE_FUNC_ARGS)
 						{
 							if (type == PT_SPRK) // spark hack
 								sim->part_change_type(p, xCopyTo, yCopyTo, PT_SPRK);
-							if (type == PT_FIGH) { // does not like the easy appraoch
+							if (type == PT_FIGH || type == PT_STKM || type == PT_STKM2) { // does not like the easy appraoch
                                 const auto& other = parts[ID(pmap[yCurrent][xCurrent])];
                                 parts[p].ctype = other.ctype;
                                 parts[p].life = other.life;
-                                // do not copy tmp -- it dhould be unique
-                                parts[p].tmp2 = other.tmp2;
+                                // do not copy tmp -- it should be unique
+                                if(type==PT_STKM) {
+                                    parts[p].tmp2 = Element_FIGH_square_head_mask;
+                                } else if(type==PT_STKM2) {
+                                    parts[p].tmp2 = Element_FIGH_square_head_mask;
+                                    parts[p].tmp2 |= Element_FIGH_stk2_mask;
+                                } else {
+                                    parts[p].tmp2 = other.tmp2;
+                                }
+
+//                                playerst& new_figh = sim->fighters[parts[p].tmp];
+//                                const playerst *cplayer = nullptr;
+//                                if(type==PT_STKM)
+//                                    cplayer = &sim->player;
+//                                else if(type==PT_STKM2)
+//                                    cplayer = &sim->player2;
+//                                else if (type==PT_FIGH && sim->parts[i].tmp >= 0 && other.tmp < MAX_FIGHTERS)
+//                                    cplayer = &sim->fighters[(unsigned char)other.tmp];
+//
+//                                int dx = xCopyTo - x;
+//                                int dy = yCopyTo - y;
+//
+//                                if (cplayer) {
+//                                    printf("legs\t old\t new\n");                                      
+//                                    for (int i=0; i<8; i++){
+//                                        new_figh.legs[i*2] = cplayer->legs[i*2] + dx;
+//                                        new_figh.legs[i*2+1] = cplayer->legs[i*2+1] + dy;
+//                                        new_figh.accs[i] = cplayer->accs[i];   
+//                                    }
+//                                }
                             } else 
                                 if (isEnergy)
 								parts[p] = parts[ID(sim->photons[yCurrent][xCurrent])];

--- a/src/simulation/elements/FIGH.cpp
+++ b/src/simulation/elements/FIGH.cpp
@@ -171,7 +171,7 @@ static int update(UPDATE_FUNC_ARGS)
 				figh->comm = (int)figh->comm | 0x04;
 		}
 		break;
-	deafault:
+	default:
 		figh->comm = 0;
 		break;
 	}

--- a/src/simulation/elements/FIGH.cpp
+++ b/src/simulation/elements/FIGH.cpp
@@ -70,11 +70,39 @@ static int update(UPDATE_FUNC_ARGS)
 
 	int tarx = 0, tary = 0;
 
-	parts[i].tmp2 = 0; //0 - stay in place, 1 - seek a stick man
+	parts[i].tmp2 &= ~Element_FIGH_moves_mask; 
 
-	//Set target cords
-	if (sim->player2.spwn)
-	{
+	// Set target cords
+    // If we are a cloned STKM, attack other fighters.
+    // If no fighters remain, turn on your creator like Frakenstein's monster
+	if (parts[i].tmp2 & Element_FIGH_square_head_mask) 
+    {
+
+        auto dist2 = [figh](playerst* f){
+            double dx = f->legs[2] - figh->legs[2];
+            double dy = f->legs[3] - figh->legs[3];
+            return dx*dx + dy*dy;
+        };
+        // stkm clone
+        float best_dist2 = 2000*2000;
+        playerst* target_figh = nullptr;
+        for (unsigned char j=0; j<MAX_FIGHTERS; ++j){
+            playerst* f = &sim->fighters[j];
+            if (f->spwn != 0 && f != figh && dist2(f) < best_dist2) {
+                best_dist2 = dist2(f);
+                target_figh = f;
+            }
+        }
+
+        if (target_figh != nullptr){
+            // successfully found
+            tarx = (int)target_figh->legs[2];
+            tary = (int)target_figh->legs[3];
+            parts[i].tmp2 |= Element_FIGH_moves_mask;
+        }
+    } 
+    else if (sim->player2.spwn)
+    {
 		if (sim->player.spwn && (pow((float)sim->player.legs[2]-x, 2) + pow((float)sim->player.legs[3]-y, 2))<=
 		   (pow((float)sim->player2.legs[2]-x, 2) + pow((float)sim->player2.legs[3]-y, 2)))
 		{
@@ -86,16 +114,17 @@ static int update(UPDATE_FUNC_ARGS)
 			tarx = (int)sim->player2.legs[2];
 			tary = (int)sim->player2.legs[3];
 		}
-		parts[i].tmp2 = 1;
+		parts[i].tmp2 |= Element_FIGH_moves_mask;
 	}
 	else if (sim->player.spwn)
 	{
 		tarx = (int)sim->player.legs[2];
 		tary = (int)sim->player.legs[3];
-		parts[i].tmp2 = 1;
-	}
+		parts[i].tmp2 |= Element_FIGH_moves_mask;
 
-	switch (parts[i].tmp2)
+	} 
+
+	switch (parts[i].tmp2 & Element_FIGH_moves_mask)
 	{
 	case 1:
 		if ((pow(float(tarx-x), 2) + pow(float(tary-y), 2))<600)
@@ -142,7 +171,7 @@ static int update(UPDATE_FUNC_ARGS)
 				figh->comm = (int)figh->comm | 0x04;
 		}
 		break;
-	default:
+	deafault:
 		figh->comm = 0;
 		break;
 	}


### PR DESCRIPTION
Degrades DRAY behaviour to copying only ctype, life and tmp2 on these special particles, in a way one might expect naively.

Main Summary
+ Add a check for DRAY when copying legged particles
+ Adds a new .tmp2 mode for FIGH to give it a square head if 0x2 bit of tmp2 is set
+ Adds a new .tmp2 mode for FIGH to give it purple legs if 0x4 bit of tmp2 is set

Square headed fighters are 'player brained' in that they will hunt down and attempt to fight FIGH (in practice, they usually just kill themselves). If no fighters remain, they will hunt down their creators, Shelley-style.

It's a bit jank, yes, but so is all of the fighter/stickman code. I'd argue that this is at least an improvement on the current state, where dray makes two-headed stickmen.

Comments and criticism welcome. This is my first PR on TPT, be gentle with me on bad code style.