### PR TITLE
Make DRAY able to copy fighters correctly

### DIFF
--- a/src/simulation/elements/DRAY.cpp
+++ b/src/simulation/elements/DRAY.cpp
@@ -155,13 +155,15 @@ static int update(UPDATE_FUNC_ARGS)
 						// if new particle was created successfully
 						if (p >= 0)
 						{
-                            if (type == PT_SPRK) { // spark hack
+                            if (type == PT_SPRK)  // spark hack
                                 sim->part_change_type(p, xCopyTo, yCopyTo, PT_SPRK);
-                            }
 
 							if (isEnergy)
 								parts[p] = parts[ID(sim->photons[yCurrent][xCurrent])];
-                            else if (type == PT_FIGH) { 
+                            else if (type != PT_FIGH) 
+                                parts[p] = parts[ID(pmap[yCurrent][xCurrent])];
+                            else
+                            { 
                                 // FIGH needs special rules
                                 const auto& other = parts[ID(pmap[yCurrent][xCurrent])];
                                 const playerst& source_pst = sim->fighters[other.tmp];
@@ -177,8 +179,7 @@ static int update(UPDATE_FUNC_ARGS)
                                 this_pst.fan = source_pst.fan;
                                 this_pst.elem = source_pst.elem;
 
-                            } else 	
-                                parts[p] = parts[ID(pmap[yCurrent][xCurrent])];
+                            } 
 
 							parts[p].x = float(xCopyTo);
 							parts[p].y = float(yCopyTo);

--- a/src/simulation/elements/DRAY.cpp
+++ b/src/simulation/elements/DRAY.cpp
@@ -106,8 +106,8 @@ static int update(UPDATE_FUNC_ARGS)
 							rr = pmap[yCurrent][xCurrent];
 
 						// Checks for when to stop:
-						//  1: if .tmp isn't set, and the element in this spot is the ctype, then stop
-						//  2: if .tmp is set, stop when the length limit reaches 0
+						//	1: if .tmp isn't set, and the element in this spot is the ctype, then stop
+						//	2: if .tmp is set, stop when the length limit reaches 0
 						if ((!localCopyLength && TYP(rr) == ctype && (ctype != PT_LIFE || parts[ID(rr)].ctype == ctypeExtra))
 								|| !--partsRemaining)
 						{
@@ -145,8 +145,8 @@ static int update(UPDATE_FUNC_ARGS)
 						}
 						if (type == PT_SPRK) // spark hack
 							p = sim->create_part(-1, xCopyTo, yCopyTo, PT_METL);
-                        else if (type == PT_STKM || type == PT_STKM2)
-                            continue; // do not try to copy these non-copyable particles
+						else if (type == PT_STKM || type == PT_STKM2)
+							continue; // do not try to copy these non-copyable particles
 						else if (type)
 							p = sim->create_part(-1, xCopyTo, yCopyTo, type);
 						else
@@ -155,31 +155,31 @@ static int update(UPDATE_FUNC_ARGS)
 						// if new particle was created successfully
 						if (p >= 0)
 						{
-                            if (type == PT_SPRK)  // spark hack
-                                sim->part_change_type(p, xCopyTo, yCopyTo, PT_SPRK);
+							if (type == PT_SPRK) // spark hack
+								sim->part_change_type(p, xCopyTo, yCopyTo, PT_SPRK);
 
 							if (isEnergy)
 								parts[p] = parts[ID(sim->photons[yCurrent][xCurrent])];
-                            else if (type != PT_FIGH) 
-                                parts[p] = parts[ID(pmap[yCurrent][xCurrent])];
-                            else
-                            { 
-                                // FIGH needs special rules
-                                const auto& other = parts[ID(pmap[yCurrent][xCurrent])];
-                                const playerst& source_pst = sim->fighters[other.tmp];
-                                auto old_tmp = parts[p].tmp;
-                                parts[p] = other;
-                                parts[p].tmp = old_tmp; 
-                                // need to keep .tmp consistent, since this
-                                // is a pointer to fighter metadata
+							else if (type != PT_FIGH) 
+								parts[p] = parts[ID(pmap[yCurrent][xCurrent])];
+							else
+							{ 
+								// FIGH needs special rules
+								const auto& other = parts[ID(pmap[yCurrent][xCurrent])];
+								const playerst& source_pst = sim->fighters[other.tmp];
+								auto old_tmp = parts[p].tmp;
+								parts[p] = other;
+								parts[p].tmp = old_tmp; 
+								// need to keep .tmp consistent: it points to fighter metadata
 
-                                // also update the fighter metadata
-                                playerst& this_pst = sim->fighters[old_tmp];
-                                this_pst.rocketBoots = source_pst.rocketBoots;
-                                this_pst.fan = source_pst.fan;
-                                this_pst.elem = source_pst.elem;
+								// Update the new fighter's metadata
+								// Do not attempt to copy kinematics of legs - overwritten next frame anyway
+								playerst& this_pst = sim->fighters[old_tmp];
+								this_pst.rocketBoots = source_pst.rocketBoots;
+								this_pst.fan = source_pst.fan;
+								this_pst.elem = source_pst.elem;
 
-                            } 
+							} 
 
 							parts[p].x = float(xCopyTo);
 							parts[p].y = float(yCopyTo);

--- a/src/simulation/elements/DRAY.cpp
+++ b/src/simulation/elements/DRAY.cpp
@@ -160,26 +160,27 @@ static int update(UPDATE_FUNC_ARGS)
 
 							if (isEnergy)
 								parts[p] = parts[ID(sim->photons[yCurrent][xCurrent])];
-							else if (type != PT_FIGH) 
+							else if (type != PT_FIGH)
 								parts[p] = parts[ID(pmap[yCurrent][xCurrent])];
 							else
-							{ 
+							{
 								// FIGH needs special rules
 								const auto& other = parts[ID(pmap[yCurrent][xCurrent])];
-								const playerst& source_pst = sim->fighters[other.tmp];
+
+								// need to keep .tmp consistent: it points to fighter metadata
 								auto old_tmp = parts[p].tmp;
 								parts[p] = other;
-								parts[p].tmp = old_tmp; 
-								// need to keep .tmp consistent: it points to fighter metadata
+								parts[p].tmp = old_tmp;
 
 								// Update the new fighter's metadata
 								// Do not attempt to copy kinematics of legs - overwritten next frame anyway
+								const playerst& source_pst = sim->fighters[other.tmp];
 								playerst& this_pst = sim->fighters[old_tmp];
 								this_pst.rocketBoots = source_pst.rocketBoots;
 								this_pst.fan = source_pst.fan;
 								this_pst.elem = source_pst.elem;
 
-							} 
+							}
 
 							parts[p].x = float(xCopyTo);
 							parts[p].y = float(yCopyTo);

--- a/src/simulation/elements/DRAY.cpp
+++ b/src/simulation/elements/DRAY.cpp
@@ -145,6 +145,8 @@ static int update(UPDATE_FUNC_ARGS)
 						}
 						if (type == PT_SPRK) // spark hack
 							p = sim->create_part(-1, xCopyTo, yCopyTo, PT_METL);
+                        else if (type == PT_STKM || type == PT_STKM2)
+                            continue; // do not try to copy these non-copyably particles
 						else if (type)
 							p = sim->create_part(-1, xCopyTo, yCopyTo, type);
 						else
@@ -153,12 +155,31 @@ static int update(UPDATE_FUNC_ARGS)
 						// if new particle was created successfully
 						if (p >= 0)
 						{
-							if (type == PT_SPRK) // spark hack
-								sim->part_change_type(p, xCopyTo, yCopyTo, PT_SPRK);
+                            if (type == PT_SPRK) { // spark hack
+                                sim->part_change_type(p, xCopyTo, yCopyTo, PT_SPRK);
+                            }
+
 							if (isEnergy)
 								parts[p] = parts[ID(sim->photons[yCurrent][xCurrent])];
-							else
-								parts[p] = parts[ID(pmap[yCurrent][xCurrent])];
+                            else if (type == PT_FIGH) { 
+                                // FIGH needs special rules
+                                const auto& other = parts[ID(pmap[yCurrent][xCurrent])];
+                                const playerst& source_pst = sim->fighters[other.tmp];
+                                playerst& this_pst = sim->fighters[parts[p].tmp];
+                            
+                                parts[p].ctype = other.ctype;
+                                parts[p].life  = other.life;
+                                parts[p].tmp2  = other.tmp2;
+                                parts[p].tmp3  = other.tmp3;
+                                parts[p].tmp4  = other.tmp4;
+
+                                this_pst.rocketBoots = source_pst.rocketBoots;
+                                this_pst.fan = source_pst.fan;
+                                this_pst.elem = source_pst.elem;
+
+                            } else 	
+                                parts[p] = parts[ID(pmap[yCurrent][xCurrent])];
+
 							parts[p].x = float(xCopyTo);
 							parts[p].y = float(yCopyTo);
 						}

--- a/src/simulation/elements/DRAY.cpp
+++ b/src/simulation/elements/DRAY.cpp
@@ -146,7 +146,7 @@ static int update(UPDATE_FUNC_ARGS)
 						if (type == PT_SPRK) // spark hack
 							p = sim->create_part(-1, xCopyTo, yCopyTo, PT_METL);
                         else if (type == PT_STKM || type == PT_STKM2)
-                            continue; // do not try to copy these non-copyably particles
+                            continue; // do not try to copy these non-copyable particles
 						else if (type)
 							p = sim->create_part(-1, xCopyTo, yCopyTo, type);
 						else
@@ -165,14 +165,14 @@ static int update(UPDATE_FUNC_ARGS)
                                 // FIGH needs special rules
                                 const auto& other = parts[ID(pmap[yCurrent][xCurrent])];
                                 const playerst& source_pst = sim->fighters[other.tmp];
-                                playerst& this_pst = sim->fighters[parts[p].tmp];
-                            
-                                parts[p].ctype = other.ctype;
-                                parts[p].life  = other.life;
-                                parts[p].tmp2  = other.tmp2;
-                                parts[p].tmp3  = other.tmp3;
-                                parts[p].tmp4  = other.tmp4;
+                                auto old_tmp = parts[p].tmp;
+                                parts[p] = other;
+                                parts[p].tmp = old_tmp; 
+                                // need to keep .tmp consistent, since this
+                                // is a pointer to fighter metadata
 
+                                // also update the fighter metadata
+                                playerst& this_pst = sim->fighters[old_tmp];
                                 this_pst.rocketBoots = source_pst.rocketBoots;
                                 this_pst.fan = source_pst.fan;
                                 this_pst.elem = source_pst.elem;

--- a/src/simulation/elements/DRAY.cpp
+++ b/src/simulation/elements/DRAY.cpp
@@ -174,12 +174,14 @@ static int update(UPDATE_FUNC_ARGS)
 
 								// Update the new fighter's metadata
 								// Do not attempt to copy kinematics of legs - overwritten next frame anyway
-								const playerst& source_pst = sim->fighters[other.tmp];
-								playerst& this_pst = sim->fighters[old_tmp];
-								this_pst.rocketBoots = source_pst.rocketBoots;
-								this_pst.fan = source_pst.fan;
-								this_pst.elem = source_pst.elem;
-
+								if (other.tmp >= 0 && other.tmp < MAX_FIGHTERS)
+								{
+									const playerst& source_pst = sim->fighters[other.tmp];
+									playerst& this_pst = sim->fighters[old_tmp];
+									this_pst.rocketBoots = source_pst.rocketBoots;
+									this_pst.fan = source_pst.fan;
+									this_pst.elem = source_pst.elem;
+								}
 							}
 
 							parts[p].x = float(xCopyTo);


### PR DESCRIPTION
+ DRAY on STKM/STK2 no longer makes double heads (refuses to copy instead)
+ DRAY on FIGH copies all particle properties except .tmp (needed for metadata lookup)

I tried to also update the legs and acc fields; results looked much worse than this simple thing. Since STKM may be rewritten soon, I don't think the extra effort to copy these correctly is worthwhile.