### PR TITLE
Update FOG cloner exclusion list

### DIFF
--- a/src/simulation/elements/FOG.cpp
+++ b/src/simulation/elements/FOG.cpp
@@ -59,7 +59,7 @@ static int update(UPDATE_FUNC_ARGS)
 				auto r = pmap[y+ry][x+rx];
 				if (!r)
 					continue;
-				if ((elements[TYP(r)].Properties&TYPE_SOLID) && sim->rng.chance(1, 10) && parts[i].life==0 && !(TYP(r)==PT_CLNE || TYP(r)==PT_PCLN)) // TODO: should this also exclude BCLN?
+				if ((elements[TYP(r)].Properties&TYPE_SOLID) && sim->rng.chance(1, 10) && parts[i].life==0 && !(TYP(r)==PT_CLNE || TYP(r)==PT_PCLN || TYP(r)==PT_BCLN || TYP(r)==PT_PBCN))
 				{
 					sim->part_change_type(i,x,y,PT_RIME);
 				}


### PR DESCRIPTION
Updates the FOG solidification exclusion list to include BCLN and PBCN, ensuring all fog cloner interactions will behave the same. Resolves a TODO.