### PR TITLE
Macos build improvements

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -390,15 +390,6 @@ if host_platform == 'windows'
 		endif
 	endforeach
 	project_cpp_args += args_ccomp_win
-elif host_platform == 'darwin'
-	# work around assertion failure with LTO symbols
-	# https://developer.apple.com/documentation/xcode-release-notes/xcode-15-release-notes#Linking
-	# otherwise we get ld: Assertion failed: (0 && "lto symbol should not be in layout"), function symbolForAtom, file Layout.cpp, line 1447.
-	# TODO: remove when appropriate
-	if is_static and cpp_compiler.has_link_argument('-ld_classic')
-		warning('applying broken apple clang linker workaround with -ld_classic')
-		project_link_args += [ '-ld_classic' ]
-	endif
 elif host_platform == 'android'
 	args_ccomp_android = []
 	if not is_64bit

--- a/src/Format.cpp
+++ b/src/Format.cpp
@@ -2,8 +2,6 @@
 #include <cstdio>
 #include <cstring>
 #include <ctime>
-#include <iostream>
-#include <iterator>
 #include <optional>
 #include <stdexcept>
 #include <png.h>
@@ -24,7 +22,7 @@ ByteString format::UnixtimeToDate(time_t unixtime, ByteString dateFormat, bool l
 		timeData = gmtime(&unixtime);
 	}
 
-	strftime(buffer, 128, dateFormat.c_str(), timeData);
+	strftime(buffer, sizeof(buffer), dateFormat.c_str(), timeData);
 	return ByteString(buffer);
 }
 
@@ -105,9 +103,8 @@ String format::CleanString(String dirtyString, bool ascii, bool color, bool newl
 std::vector<char> format::PixelsToPPM(PlaneAdapter<std::vector<pixel>> const &input)
 {
 	std::vector<char> data;
-	char buffer[256];
-	sprintf(buffer, "P6\n%d %d\n255\n", input.Size().X, input.Size().Y);
-	data.insert(data.end(), buffer, buffer + strlen(buffer));
+	ByteString header = ByteString::Build("P6\n", input.Size().X, " ", input.Size().Y, "\n255\n");
+	data.insert(data.end(), header.begin(), header.end());
 
 	data.reserve(data.size() + input.Size().X * input.Size().Y * 3);
 


### PR DESCRIPTION
1. Addresses the following warnings when compiling on MacOS

```
7/61] Compiling C++ object libcommon.a.p/src_Format.cpp.o
../src/Format.cpp:109:2: warning: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Wdeprecated-declarations]
  109 |         sprintf(buffer, "P6\n%d %d\n255\n", input.Size().X, input.Size().Y);
      |         ^
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/_stdio.h:278:1: note: 'sprintf' has been explicitly marked deprecated here
  278 | __deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
      | ^
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/sys/cdefs.h:227:48: note: expanded from macro '__deprecated_msg'
  227 |         #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
      |                                                       ^
1 warning generated.
[60/61] Linking target powder
ld: warning: -ld_classic is deprecated and will be removed in a future release
```
Uses `snprintf` instead of `sprintf`. Note: this is only to satisfy the linter - the exact format string used cannot cause a buffer overflow since 2 integers can't be more than 255 characters. But the fix has no downsides. 

Removes `-ld_classic` linking flag. It is no longer needed as of XCode 15.1 and will be removed soon. 

2. Implements Flush to Zero for denormalized floats to match x86-64 optimization behavior. This does not produce noticeable performance improvement with an M1 Pro processor, but in theory it should have the same benefit as `_MM_FLUSH_ZERO_ON` on x86

https://developer.arm.com/documentation/ddi0487/mb/-Part-A-Arm-Architecture-Introduction-and-Overview/-Chapter-A1-Introduction-to-the-Arm-Architecture/-A1-5-Floating-point-support/-A1-5-6-Flushing-denormalized-numbers-to-zero?lang=en

Builds tested on M1 Macbook Pro and Raspberry Pi 4b 
