### PR TITLE
Fix bug in URLDecode

### DIFF
--- a/src/Format.cpp
+++ b/src/Format.cpp
@@ -325,13 +325,13 @@ ByteString format::URLDecode(ByteString source)
 	ByteString result;
 	for (auto it = source.begin(); it < source.end(); ++it)
 	{
-		if (*it == '%' && it < source.end() + 2)
+		if (*it == '%' && it + 2 < source.end())
 		{
 			auto byte = uint8_t(0);
 			for (auto i = 0; i < 2; ++i)
 			{
 				it += 1;
-				auto *off = strchr(hex, tolower(*it));
+				auto *off = strchr(hex, toupper(*it));
 				if (!off)
 				{
 					return {};


### PR DESCRIPTION
Lowercase --> uppercase: the constant with hex characters has uppercase letters, but the URLDecode function checks for lowercase letters

Incorrect indexing: the loop guard incorrectly checked up to 2 characters past the end of the string. This probably wouldn't have caused an issue, but is still wrong. 

Casting issues: I changed some types around to improve style

Previously if you try to open a file named `*test*.cps` by doing `./powder 'file:///%2atest%2a.cps'` it would not work due to the lowercase check and indexing issue