### PR TITLE
Replace PlaneBase with std::span

### DIFF
--- a/src/client/GameSave.cpp
+++ b/src/client/GameSave.cpp
@@ -783,10 +783,10 @@ void GameSave::readOPS(const std::vector<char> &data)
 	//Read wall and fan data
 	if(wallData.data())
 	{
-		auto wallDataPlane = PlaneAdapter<PlaneBase<const unsigned char>>(blockS, std::in_place, wallData.data());
 		unsigned int j = 0;
 		if (blockS.X * blockS.Y > int(wallData.size()))
 			throw ParseException(ParseException::Corrupt, "Not enough wall data");
+		auto wallDataPlane = MakePlane(blockS, wallData.data());
 		for (auto bpos : blockS.OriginRect().Range<LEFT_TO_RIGHT, TOP_TO_BOTTOM>())
 		{
 			unsigned char bm = 0;
@@ -895,8 +895,8 @@ void GameSave::readOPS(const std::vector<char> &data)
 	{
 		if (blockS.X * blockS.Y * 2 > int(blockAirData.size()))
 			throw ParseException(ParseException::Corrupt, "Not enough block air data");
-		auto blockAirDataPlane = PlaneAdapter<PlaneBase<const unsigned char>>(blockS, std::in_place, blockAirData.data());
-		auto blockAirhDataPlane = PlaneAdapter<PlaneBase<const unsigned char>>(blockS, std::in_place, blockAirData.data() + blockS.X * blockS.Y);
+		auto blockAirDataPlane = MakePlane(blockS, blockAirData.data());
+		auto blockAirhDataPlane = MakePlane(blockS, blockAirData.data() + blockS.X * blockS.Y);
 		for (auto bpos : blockS.OriginRect().Range<LEFT_TO_RIGHT, TOP_TO_BOTTOM>())
 		{
 			blockAir [blockP + bpos] = blockAirDataPlane [bpos];
@@ -911,10 +911,10 @@ void GameSave::readOPS(const std::vector<char> &data)
 		{
 			throw ParseException(ParseException::Corrupt, "Not enough gravity data");
 		}
-		auto massDataPlane   = PlaneAdapter<PlaneBase<const float   >>(blockS, std::in_place, reinterpret_cast<const float    *>(gravityData.data()                                          ));
-		auto maskDataPlane   = PlaneAdapter<PlaneBase<const uint32_t>>(blockS, std::in_place, reinterpret_cast<const uint32_t *>(gravityData.data() +     blockS.X * blockS.Y * sizeof(float)));
-		auto forceXDataPlane = PlaneAdapter<PlaneBase<const float   >>(blockS, std::in_place, reinterpret_cast<const float    *>(gravityData.data() + 2 * blockS.X * blockS.Y * sizeof(float)));
-		auto forceYDataPlane = PlaneAdapter<PlaneBase<const float   >>(blockS, std::in_place, reinterpret_cast<const float    *>(gravityData.data() + 3 * blockS.X * blockS.Y * sizeof(float)));
+		auto massDataPlane   = MakePlane(blockS, reinterpret_cast<const float    *>(gravityData.data()));
+		auto maskDataPlane   = MakePlane(blockS, reinterpret_cast<const uint32_t *>(gravityData.data() +     blockS.X * blockS.Y * sizeof(float)));
+		auto forceXDataPlane = MakePlane(blockS, reinterpret_cast<const float    *>(gravityData.data() + 2 * blockS.X * blockS.Y * sizeof(float)));
+		auto forceYDataPlane = MakePlane(blockS, reinterpret_cast<const float    *>(gravityData.data() + 3 * blockS.X * blockS.Y * sizeof(float)));
 		for (auto bpos : blockS.OriginRect().Range<LEFT_TO_RIGHT, TOP_TO_BOTTOM>())
 		{
 			gravMass  [blockP + bpos] = massDataPlane  [bpos];
@@ -1481,7 +1481,7 @@ void GameSave::readPSv(const std::vector<char> &dataVec)
 	}
 	for (auto bpos : RectSized(blockP, blockS).Range<TOP_TO_BOTTOM, LEFT_TO_RIGHT>())
 	{
-		auto dataPlane = PlaneAdapter<PlaneBase<const unsigned char>>(blockS, std::in_place, data);
+		auto dataPlane = MakePlane(blockS, data);
 		if (dataPlane[bpos - blockP]==4||(ver>=44 && dataPlane[bpos - blockP]==O_WL_FAN))
 		{
 			if (p >= dataLength)
@@ -1491,7 +1491,7 @@ void GameSave::readPSv(const std::vector<char> &dataVec)
 	}
 	for (auto bpos : RectSized(blockP, blockS).Range<TOP_TO_BOTTOM, LEFT_TO_RIGHT>())
 	{
-		auto dataPlane = PlaneAdapter<PlaneBase<const unsigned char>>(blockS, std::in_place, data);
+		auto dataPlane = MakePlane(blockS, data);
 		if (dataPlane[bpos - blockP]==4||(ver>=44 && dataPlane[bpos - blockP]==O_WL_FAN))
 		{
 			if (p >= dataLength)
@@ -1607,7 +1607,7 @@ void GameSave::readPSv(const std::vector<char> &dataVec)
 			}
 		}
 	}
-	auto dataPlanePty = PlaneAdapter<PlaneBase<const unsigned char>>(partS, std::in_place, data + pty);
+	auto dataPlanePty = MakePlane(partS, data + pty);
 	if (ver>=53) {
 		for (auto pos : partS.OriginRect().Range<TOP_TO_BOTTOM, LEFT_TO_RIGHT>())
 		{
@@ -1983,7 +1983,7 @@ std::pair<bool, std::vector<char>> GameSave::serialiseOPS() const
 
 	// Copy fan and wall data
 	std::vector<unsigned char> wallDataBacking(blockSize.X*blockSize.Y);
-	PlaneAdapter<PlaneBase<unsigned char>> wallData(blockSize, std::in_place, wallDataBacking.data());
+	auto wallData = MakePlane(blockSize, wallDataBacking.data());
 	bool hasWallData = false;
 	std::vector<unsigned char> fanData(blockSize.X*blockSize.Y*2);
 	std::vector<unsigned char> pressData(blockSize.X*blockSize.Y*2);
@@ -1992,14 +1992,14 @@ std::pair<bool, std::vector<char>> GameSave::serialiseOPS() const
 	std::vector<unsigned char> ambientData(blockSize.X*blockSize.Y*2, 0);
 
 	std::vector<unsigned char> blockAirData(blockSize.X * blockSize.Y * 2);
-	PlaneAdapter<PlaneBase<unsigned char>> blockAirDataPlane (blockSize, std::in_place, blockAirData.data()                            );
-	PlaneAdapter<PlaneBase<unsigned char>> blockAirhDataPlane(blockSize, std::in_place, blockAirData.data() + blockSize.X * blockSize.Y);
+	auto blockAirDataPlane  = MakePlane(blockSize, blockAirData.data());
+	auto blockAirhDataPlane = MakePlane(blockSize, blockAirData.data() + blockSize.X * blockSize.Y);
 
 	std::vector<unsigned char> gravityData(blockSize.X * blockSize.Y * 4 * sizeof(float));
-	PlaneAdapter<PlaneBase<float   >> massDataPlane  (blockSize, std::in_place, reinterpret_cast<float    *>(gravityData.data()                                                ));
-	PlaneAdapter<PlaneBase<uint32_t>> maskDataPlane  (blockSize, std::in_place, reinterpret_cast<uint32_t *>(gravityData.data() +     blockSize.X * blockSize.Y * sizeof(float)));
-	PlaneAdapter<PlaneBase<float   >> forceXDataPlane(blockSize, std::in_place, reinterpret_cast<float    *>(gravityData.data() + 2 * blockSize.X * blockSize.Y * sizeof(float)));
-	PlaneAdapter<PlaneBase<float   >> forceYDataPlane(blockSize, std::in_place, reinterpret_cast<float    *>(gravityData.data() + 3 * blockSize.X * blockSize.Y * sizeof(float)));
+	auto massDataPlane   = MakePlane(blockSize, reinterpret_cast<float    *>(gravityData.data()));
+	auto maskDataPlane   = MakePlane(blockSize, reinterpret_cast<uint32_t *>(gravityData.data() +     blockSize.X * blockSize.Y * sizeof(float)));
+	auto forceXDataPlane = MakePlane(blockSize, reinterpret_cast<float    *>(gravityData.data() + 2 * blockSize.X * blockSize.Y * sizeof(float)));
+	auto forceYDataPlane = MakePlane(blockSize, reinterpret_cast<float    *>(gravityData.data() + 3 * blockSize.X * blockSize.Y * sizeof(float)));
 
 	unsigned int fanDataLen = 0, pressDataLen = 0, vxDataLen = 0, vyDataLen = 0, ambientDataLen = 0;
 

--- a/src/common/Plane.h
+++ b/src/common/Plane.h
@@ -4,46 +4,11 @@
 #include <cstddef>
 #include <functional>
 #include <limits>
+#include <span>
 #include <type_traits>
 #include <utility>
 
 #include "common/Vec2.h"
-
-// TODO: std::span once we're C++20
-template<class Item>
-struct PlaneBase
-{
-	Item *base;
-
-	PlaneBase(Item *newBase) : base(newBase)
-	{
-	}
-
-	Item *begin()
-	{
-		return base;
-	}
-
-	const Item *begin() const
-	{
-		return base;
-	}
-
-	Item &operator [](size_t index)
-	{
-		return *(base + index);
-	}
-
-	const Item &operator [](size_t index) const
-	{
-		return *(base + index);
-	}
-
-	const Item *data() const
-	{
-		return base;
-	}
-};
 
 constexpr size_t DynamicExtent = std::numeric_limits<size_t>::max();
 
@@ -205,3 +170,10 @@ public:
 		return getBase()[p.X + p.Y * getWidth()];
 	}
 };
+
+template<size_t Width = DynamicExtent, size_t Height = DynamicExtent, typename Item>
+auto MakePlane(Vec2<int> size, Item *data)
+{
+	return PlaneAdapter<std::span<Item>, Width, Height>(size, std::in_place, data, size.X * size.Y);
+}
+

--- a/src/simulation/gravity/Fft.cpp
+++ b/src/simulation/gravity/Fft.cpp
@@ -102,7 +102,7 @@ void GravityImpl::Wait()
 void GravityImpl::Work()
 {
 	{
-		PlaneAdapter<PlaneBase<float>, blocks.X, blocks.Y> massBigP(blocks, std::in_place, massBig.get());
+		auto massBigP = MakePlane<blocks.X, blocks.Y>(blocks, massBig.get());
 		for (auto p : CELLS.OriginRect())
 		{
 			// used to be a membwand but we'd need a new buffer for this,
@@ -122,8 +122,8 @@ void GravityImpl::Work()
 	fftwf_execute(forceXInverse.get());
 	fftwf_execute(forceYInverse.get());
 	{
-		PlaneAdapter<PlaneBase<float>, blocks.X, blocks.Y> forceXBigP(blocks, std::in_place, forceXBig.get());
-		PlaneAdapter<PlaneBase<float>, blocks.X, blocks.Y> forceYBigP(blocks, std::in_place, forceYBig.get());
+		auto forceXBigP = MakePlane<blocks.X, blocks.Y>(blocks, forceXBig.get());
+		auto forceYBigP = MakePlane<blocks.X, blocks.Y>(blocks, forceYBig.get());
 		for (auto p : CELLS.OriginRect())
 		{
 			// similarly
@@ -157,8 +157,8 @@ void GravityImpl::Init()
 	auto kernelYRaw = FftwArray(blocks.X * blocks.Y);
 	auto kernelXForward = FftwPlanPtr(fftwf_plan_dft_r2c_2d(blocks.Y, blocks.X, kernelXRaw.get(), reinterpret_cast<fftwf_complex *>(kernelXT.get()), fftwPlanFlags));
 	auto kernelYForward = FftwPlanPtr(fftwf_plan_dft_r2c_2d(blocks.Y, blocks.X, kernelYRaw.get(), reinterpret_cast<fftwf_complex *>(kernelYT.get()), fftwPlanFlags));
-	PlaneAdapter<PlaneBase<float>, blocks.X, blocks.Y> kernelX(blocks, std::in_place, kernelXRaw.get());
-	PlaneAdapter<PlaneBase<float>, blocks.X, blocks.Y> kernelY(blocks, std::in_place, kernelYRaw.get());
+	auto kernelX = MakePlane<blocks.X, blocks.Y>(blocks, kernelXRaw.get());
+	auto kernelY = MakePlane<blocks.X, blocks.Y>(blocks, kernelYRaw.get());
 	//calculate velocity map caused by a point mass
 	for (auto p : blocks.OriginRect())
 	{


### PR DESCRIPTION
While looking through TODOs I found that the `PlaneBase` wrapper was slated for replacement with `std::span` once the game is C++20. Given that it's thoroughly C++20 now, I've done that. This is pretty much a drop-in replacement for modernization purposes. I haven't experienced any issues in my own gameplay/testing with these changes.