### PR TITLE
Add binary (0b) and octal (0o) input support for PROP tool

### DIFF
--- a/src/simulation/AccessPropertyParse.cpp
+++ b/src/simulation/AccessPropertyParse.cpp
@@ -5,6 +5,7 @@
 #include "Config.h"
 #include "Format.h"
 #include "gui/game/GameController.h"
+#include <cstdlib>
 #include <iostream>
 
 AccessProperty AccessProperty::Parse(int prop, String value)
@@ -30,6 +31,20 @@ AccessProperty AccessProperty::Parse(int prop, String value)
 			{
 				//0xC0FFEE
 				v = value.Substr(2).ToNumber<unsigned int>(Format::Hex());
+			}
+			else if(value.length() > 2 && value.BeginsWith("0B"))
+			{
+				//0b1010
+				auto substr = value.Substr(2).ToUtf8();
+				char *endptr;
+				v = (int)std::strtol(substr.c_str(), &endptr, 2);
+				if (*endptr)
+					throw std::runtime_error("Not a number");
+			}
+			else if(value.length() > 2 && value.BeginsWith("0O"))
+			{
+				//0o777
+				v = value.Substr(2).ToNumber<unsigned int>(Format::Oct());
 			}
 			else if(value.length() > 1 && value.BeginsWith("#"))
 			{
@@ -110,6 +125,20 @@ AccessProperty AccessProperty::Parse(int prop, String value)
 			{
 				//0xC0FFEE
 				v = value.Substr(2).ToNumber<unsigned int>(Format::Hex());
+			}
+			else if(value.length() > 2 && value.BeginsWith("0B"))
+			{
+				//0b1010
+				auto substr = value.Substr(2).ToUtf8();
+				char *endptr;
+				v = (unsigned int)std::strtoul(substr.c_str(), &endptr, 2);
+				if (*endptr)
+					throw std::runtime_error("Not a number");
+			}
+			else if(value.length() > 2 && value.BeginsWith("0O"))
+			{
+				//0o777
+				v = value.Substr(2).ToNumber<unsigned int>(Format::Oct());
 			}
 			else if(value.length() > 1 && value.BeginsWith("#"))
 			{

--- a/src/simulation/AccessPropertyParse.cpp
+++ b/src/simulation/AccessPropertyParse.cpp
@@ -41,11 +41,6 @@ AccessProperty AccessProperty::Parse(int prop, String value)
 				if (*endptr)
 					throw std::runtime_error("Not a number");
 			}
-			else if(value.length() > 2 && value.BeginsWith("0O"))
-			{
-				//0o777
-				v = value.Substr(2).ToNumber<unsigned int>(Format::Oct());
-			}
 			else if(value.length() > 1 && value.BeginsWith("#"))
 			{
 				//#C0FFEE
@@ -134,11 +129,6 @@ AccessProperty AccessProperty::Parse(int prop, String value)
 				v = (unsigned int)std::strtoul(substr.c_str(), &endptr, 2);
 				if (*endptr)
 					throw std::runtime_error("Not a number");
-			}
-			else if(value.length() > 2 && value.BeginsWith("0O"))
-			{
-				//0o777
-				v = value.Substr(2).ToNumber<unsigned int>(Format::Oct());
 			}
 			else if(value.length() > 1 && value.BeginsWith("#"))
 			{


### PR DESCRIPTION
The PROP tool's property value parser (AccessProperty::Parse) now accepts 0b prefix for binary numbers (e.g. 0b1010) and 0o prefix for octal numbers (e.g. 0o777). Both Integer/ParticleType and UInteger property types are supported.