### PR TITLE
Sanitize FRAY tmp

### DIFF
--- a/src/client/GameSave.cpp
+++ b/src/client/GameSave.cpp
@@ -1257,6 +1257,13 @@ void GameSave::readOPS(const std::vector<char> &data)
 							particles[newIndex].tmp = builtinGol[particles[newIndex].ctype].colour2.Pack();
 						}
 					}
+                case PT_FRAY:
+                    if (savedVersion < 100)
+                    {
+                        if (particles[newIndex].tmp == 0)
+                            particles[newIndex].tmp = 10;
+                        particles[newIndex].tmp += 1;
+                    }
 				}
 				if (PressureInTmp3(particles[newIndex].type))
 				{

--- a/src/client/GameSave.cpp
+++ b/src/client/GameSave.cpp
@@ -1257,13 +1257,6 @@ void GameSave::readOPS(const std::vector<char> &data)
 							particles[newIndex].tmp = builtinGol[particles[newIndex].ctype].colour2.Pack();
 						}
 					}
-                case PT_FRAY:
-                    if (savedVersion < 100)
-                    {
-                        if (particles[newIndex].tmp == 0)
-                            particles[newIndex].tmp = 10;
-                        particles[newIndex].tmp += 1;
-                    }
 				}
 				if (PressureInTmp3(particles[newIndex].type))
 				{

--- a/src/simulation/elements/FRAY.cpp
+++ b/src/simulation/elements/FRAY.cpp
@@ -54,7 +54,7 @@ static int update(UPDATE_FUNC_ARGS)
 	if (parts[i].tmp > 0)
 		curlen = parts[i].tmp;
 	else
-		curlen = 10;
+		curlen = 11;
 	for (auto rx = -1; rx <= 1; rx++)
 	{
 		for (auto ry = -1; ry <= 1; ry++)

--- a/src/simulation/elements/FRAY.cpp
+++ b/src/simulation/elements/FRAY.cpp
@@ -68,7 +68,7 @@ static int update(UPDATE_FUNC_ARGS)
 				{
 					for (auto nxx = 0, nyy = 0, nxi = rx*-1, nyi = ry*-1, len = 0; ; nyy+=nyi, nxx+=nxi, len++)
 					{
-						if (!(x+nxi+nxx<XRES && y+nyi+nyy<YRES && x+nxi+nxx >= 0 && y+nyi+nyy >= 0) || len>curlen)
+						if (!(x+nxi+nxx<XRES && y+nyi+nyy<YRES && x+nxi+nxx >= 0 && y+nyi+nyy >= 0) || len>=curlen)
 						{
 							break;
 						}


### PR DESCRIPTION
Make FRAY behavior match the intended behavior (behavior mentioned in the wiki) which matches behavior of other elements with range set by tmp, allowing range of 1. Previously the actual range was `tmp + 1`. It is `tmp` now.