### PR TITLE
Fix gravity data size validation

### DIFF
--- a/src/client/GameSave.cpp
+++ b/src/client/GameSave.cpp
@@ -843,7 +843,7 @@ void GameSave::readOPS(const std::vector<char> &data)
 	{
 		unsigned int j = 0;
 		unsigned char i, i2;
-		if (blockS.X * blockS.Y > int(pressData.size()))
+		if (blockS.X * blockS.Y * 2> int(pressData.size()))
 			throw ParseException(ParseException::Corrupt, "Not enough pressure data");
 		for (auto bpos : blockS.OriginRect().Range<LEFT_TO_RIGHT, TOP_TO_BOTTOM>())
 		{
@@ -859,7 +859,7 @@ void GameSave::readOPS(const std::vector<char> &data)
 	{
 		unsigned int j = 0;
 		unsigned char i, i2;
-		if (blockS.X * blockS.Y > int(vxData.size()))
+		if (blockS.X * blockS.Y * 2> int(vxData.size()))
 			throw ParseException(ParseException::Corrupt, "Not enough vx data");
 		for (auto bpos : blockS.OriginRect().Range<LEFT_TO_RIGHT, TOP_TO_BOTTOM>())
 		{
@@ -874,7 +874,7 @@ void GameSave::readOPS(const std::vector<char> &data)
 	{
 		unsigned int j = 0;
 		unsigned char i, i2;
-		if (blockS.X * blockS.Y > int(vyData.size()))
+		if (blockS.X * blockS.Y * 2 > int(vyData.size()))
 			throw ParseException(ParseException::Corrupt, "Not enough vy data");
 		for (auto bpos : blockS.OriginRect().Range<LEFT_TO_RIGHT, TOP_TO_BOTTOM>())
 		{

--- a/src/client/GameSave.cpp
+++ b/src/client/GameSave.cpp
@@ -915,7 +915,7 @@ void GameSave::readOPS(const std::vector<char> &data)
 
 	if (gravityData.data())
 	{
-		if (blockS.X * blockS.Y * 4 > int(gravityData.size()))
+		if (blockS.X * blockS.Y * 4 * sizeof(float) > gravityData.size())
 		{
 			throw ParseException(ParseException::Corrupt, "Not enough gravity data");
 		}

--- a/src/client/GameSave.cpp
+++ b/src/client/GameSave.cpp
@@ -888,7 +888,7 @@ void GameSave::readOPS(const std::vector<char> &data)
 	if (ambientData.data())
 	{
 		unsigned int i = 0, tempTemp;
-		if (blockS.X * blockS.Y > int(ambientData.size()))
+		if (blockS.X * blockS.Y * 2 > int(ambientData.size()))
 			throw ParseException(ParseException::Corrupt, "Not enough ambient heat data");
 		for (auto bpos : blockS.OriginRect().Range<LEFT_TO_RIGHT, TOP_TO_BOTTOM>())
 		{
@@ -1571,7 +1571,7 @@ void GameSave::readPSv(const std::vector<char> &dataVec)
 		if (i)
 		{
 			if (ver>=44) {
-				if (p >= dataLength) {
+				if (p + 1>= dataLength) {
 					throw ParseException(ParseException::Corrupt, "Not enough data at line " MTOS(__LINE__) " in " MTOS(__FILE__));
 				}
 				if (i <= NPART) {


### PR DESCRIPTION
OPS loader validated gravity cells as 4 bytes instead of the required 16
Tested Locally with modified stamp before and after, now reports the correct error instead of crashing