### PR TITLE
fix bit_tohex corrupting memory when N is bigger than 8 (fixes #1086)

### DIFF
--- a/src/lua/LuaBit.cpp
+++ b/src/lua/LuaBit.cpp
@@ -52,6 +52,8 @@ typedef union {
 #endif
 } BitNum;
 
+#include <string>
+
 /* Convert argument to bit type. */
 static UBits barg(lua_State *L, int idx)
 {
@@ -130,12 +132,15 @@ static int bit_tohex(lua_State *L)
   UBits b = barg(L, 1);
   SBits n = lua_isnone(L, 2) ? 8 : (SBits)barg(L, 2);
   const char *hexdigits = "0123456789abcdef";
-  char buf[8];
-  int i;
+  
   if (n < 0) { n = -n; hexdigits = "0123456789ABCDEF"; }
+  std::string buf(n, '0');
+
+  int i;
+  
   if (n > 8) n = 8;
   for (i = (int)n; --i >= 0; ) { buf[i] = hexdigits[b & 15]; b >>= 4; }
-  lua_pushlstring(L, buf, (size_t)n);
+  lua_pushlstring(L, buf.c_str(), (size_t)n);
   return 1;
 }
 

--- a/src/lua/LuaBit.cpp
+++ b/src/lua/LuaBit.cpp
@@ -52,8 +52,6 @@ typedef union {
 #endif
 } BitNum;
 
-#include <string>
-
 /* Convert argument to bit type. */
 static UBits barg(lua_State *L, int idx)
 {
@@ -132,15 +130,13 @@ static int bit_tohex(lua_State *L)
   UBits b = barg(L, 1);
   SBits n = lua_isnone(L, 2) ? 8 : (SBits)barg(L, 2);
   const char *hexdigits = "0123456789abcdef";
-  
-  if (n < 0) { n = -n; hexdigits = "0123456789ABCDEF"; }
-  std::string buf(n, '0');
-
+  char buf[8];
   int i;
-  
   if (n > 8) n = 8;
+  if (n < 0) { n = -n; hexdigits = "0123456789ABCDEF"; }
+  
   for (i = (int)n; --i >= 0; ) { buf[i] = hexdigits[b & 15]; b >>= 4; }
-  lua_pushlstring(L, buf.c_str(), (size_t)n);
+  lua_pushlstring(L, buf, (size_t)n);
   return 1;
 }
 


### PR DESCRIPTION
this PR changes bit_tohex by maxing its buffer variable size, and initializing it based on N instead of a constant 8

please tell me if this is horrible