### PR TITLE
Fix wrong bitmap index in flood_water rightward scan

### DIFF
--- a/src/simulation/Simulation.cpp
+++ b/src/simulation/Simulation.cpp
@@ -723,7 +723,7 @@ bool Simulation::flood_water(int x, int y, int i)
 			}
 			while (x2 < XRES-CELL)
 			{
-				if (elements[TYP(pmap[y][x2 + 1])].Falldown != 2 || bitmap[(y * XRES) + x1 - 1])
+				if (elements[TYP(pmap[y][x2 + 1])].Falldown != 2 || bitmap[(y * XRES) + x2 + 1])
 					break;
 				x2++;
 			}


### PR DESCRIPTION
## What was wrong

In `Simulation::flood_water`, the two horizontal scans that grow a scanline span
are asymmetric. The leftward scan tests `pmap` and the visited `bitmap` on the
same cell, `x1 - 1`. The rightward scan tests `pmap` at `x2 + 1` but tests the
`bitmap` at `x1 - 1`, which belongs to the other end of the span.

Every other bitmap lookup in the function refers to the cell being examined, so
this looks like a copy-paste slip rather than an intentional asymmetry.

## What it causes

At the moment the rightward scan runs, `x1` has already finished expanding, so
`bitmap[y][x1 - 1]` is normally 0 (the left scan stopped because the neighbour
was not a liquid). With that term 0, the rightward condition collapses to the
`Falldown` test alone and the bitmap is effectively ignored, so the span extends
across cells that were already visited. Those cells are then marked again and
their neighbours pushed onto the coordinate stack a second time.

The result is redundant traversal, not a wrong destination: `flood_water` still
finds the same free cells, it just walks a lot more of the body to get there.

## How to reproduce

No patch is needed to observe the redundancy, only a build with a counter added
to the span loop. Setup used here:

1. Enable water equalization (`sim.waterEqualization(1)`).
2. Create a wide, connected body of `WATR`, roughly 590 x 80 px, contained by
   walls so it cannot drain off the edge. Width matters: the defect is in the
   rightward extension, so a narrow body will not show a difference.
3. Punch a few gaps in the row above the body, which are the destinations
   `flood_water` searches for.
4. Run for a fixed number of frames and accumulate `x2 - x1 + 1` per iteration
   of the span loop, plus a count of calls.

## How to re-verify the fix

Same scenario, three runs per variant, 46332 WATR particles, 400 frames:

| | cells traversed per call | successful moves |
|---|---:|---:|
| before | 135294 / 135255 / 135286 | 1270 / 1283 / 1287 |
| after | 90535 / 90503 / 90489 | 1220 / 1222 / 1272 |

Roughly a third of the traversal was redundant. The success counts overlap
across runs (1272 after vs 1270 before), so I do not claim a behaviour change
there; the scenario has no seed control, and I would not read the small
difference in the averages as signal.

## Scope

This is not a fix for #961. Water equalization still works the way it works, and
this only removes wasted traversal inside the flood fill. I found it while
reading `flood_water` for an unrelated experiment.

The analysis and the patch were produced with the help of an LLM (Claude),
reviewed, built and measured by me.